### PR TITLE
Fix "Art (Painting)" skill not respecting deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### **Bug Fixes:**
 
+- [#203](https://github.com/deltagreen-foundryvtt/delta-green-foundry-vtt-system/issues/203) - Fixed default "Art (Painting)" custom skill from persisting despite deletion.
 - [#229](https://github.com/deltagreen-foundryvtt/delta-green-foundry-vtt-system/issues/229) - Fixed deprecation warning related to gridDistance and gridUnits.
 
 ### **Localization:**

--- a/module/deltagreen.js
+++ b/module/deltagreen.js
@@ -164,18 +164,18 @@ Hooks.on("preCreateActor", async (actor, creationData, options, userId) => {
   // If creationData has `system` then the new actor is either duplicated or imported,
   // We only want to translate the sample Typed Skill on brand new actors,
   // thus we return early if creationData has the `system` property so we do not override anything.
-  if (creationData?.system) return;
-
-  // Only translate for actor types with a default Typed Skill (agents and NPCs)
-  if (!["agent", "npc"].includes(actor.type)) return;
+  // Also, only translate actor types with a default Typed Skill (agents and NPCs)
+  if (creationData?.system || !["agent", "npc"].includes(actor.type)) return;
 
   // Translate the default typed skill for brand new actors.
-  const artLabel = game.i18n.translations.DG?.TypeSkills?.Art ?? "Art";
-  const paintingLabel =
-    game.i18n.translations.DG?.TypeSkills?.Subskills?.Painting ?? "Painting";
-
-  actor.updateSource({ "system.typedSkills.tskill_01.group": artLabel });
-  actor.updateSource({ "system.typedSkills.tskill_01.label": paintingLabel });
+  actor.updateSource({
+    "system.typedSkills.tskill_01": {
+      label: game.i18n.localize("DG.TypeSkills.Subskills.Painting"),
+      group: game.i18n.localize("DG.TypeSkills.Art"),
+      proficiency: 0,
+      failure: false,
+    },
+  });
 });
 
 // Note - this event is fired on ALL connected clients...

--- a/template.json
+++ b/template.json
@@ -241,14 +241,7 @@
             "proficiency": 0
           }
         },
-        "typedSkills": {
-          "tskill_01": {
-            "label": "Painting",
-            "group": "Art",
-            "proficiency": 0,
-            "failure": false
-          }
-        },
+        "typedSkills": {},
         "specialTraining": []
       },
       "unnatural_skills": {


### PR DESCRIPTION
## Checklist

<!-- Check one or more: -->

- [x] This is meant for the next release.

## What does this PR do?

Because the "Art (Painting)" skill was defined in `template.json`, it was getting added to any actor that didn't have it, because that file determines the data model for all Documents. I removed that declaration and instead improved the `preCreateActor` hook, which only fires on a newly created actor. This way only new actors get the "Art (Painting)" skill, and not duplicates, nor does this annoying skill persist if it is deleted.

## How to Test

<!-- List steps to test the feature or fix. Include any setup instructions. -->

1. Create new actor.
2. Confirm it has "Art (Painting)" custom skill.
3. Delete "Art (Painting)" skill.
4. Duplicate the actor. 
5. Ensure the duplicated actor does *not* have "Art (Painting)" skill
6. Refresh Foundry.
7. Ensure that neither the original actor nor the duplicated actor have the "Art (Painting) skill
8. Test that you can still create/modify/delete typed skills

## Related Issue(s)

<!-- Link to issues this PR closes/fixes. Use GitHub auto-closing keywords if appropriate. -->

Closes #203 

## Future Work

We will soon move away from `template.json` completely in #249 
