### PR TITLE
Allow disabling the display of skill tooltips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,16 @@
 
 ## Version 1.6.1 - ????-??-??
 
+### **Features:**
+
+- [#255](https://github.com/deltagreen-foundryvtt/delta-green-foundry-vtt-system/issues/255) - Added option to toggle display of tooltips per client
+
 ### **Bug Fixes:**
 
 - [#259](https://github.com/deltagreen-foundryvtt/delta-green-foundry-vtt-system/issues/259) - Fixed "Keep Sanity Private" setting in agent sheets.
 - [#263](https://github.com/deltagreen-foundryvtt/delta-green-foundry-vtt-system/issues/263) - Fixed inability to edit item descriptions.
 - [#253](https://github.com/deltagreen-foundryvtt/delta-green-foundry-vtt-system/issues/253) - Close "Automation Menu" & "Handler Settings" when settings are saved.
+- [#252](https://github.com/deltagreen-foundryvtt/delta-green-foundry-vtt-system/issues/252) - Removed redundant lines in tooltip texts
 
 ## Version 1.6.0 - 2025-09-04
 

--- a/lang/en.json
+++ b/lang/en.json
@@ -395,6 +395,8 @@
   "DG.Settings.charactersheet.program": "The Program",
   "DG.Settings.sortskills.name": "Sort Skills By Column?",
   "DG.Settings.sortskills.hint": "Checked sorts by column. Unchecked sorts by row.",
+  "DG.Settings.hideSkillTooltips.name": "Hide Skill Tooltips",
+  "DG.Settings.hideSkillTooltips.hint": "Do not display skill tooltips in Agent sheets.",
   "DG.Settings.keepSanityPrivate.name": "Keep Sanity Private",
   "DG.Settings.keepSanityPrivate.hint": "Hide sanity from players in both Agent sheets and rolls.",
   "DG.Settings.skillImprovementFormula.name": "Default Skill Improvement Roll",

--- a/module/other/register-helpers.js
+++ b/module/other/register-helpers.js
@@ -254,8 +254,4 @@ export default function registerHandlebarsHelpers() {
 
     return result;
   });
-
-  Handlebars.registerHelper("hideSkillTooltips", () => {
-    return game.settings.get("deltagreen", "hideSkillTooltips");
-  });
 }

--- a/module/other/register-helpers.js
+++ b/module/other/register-helpers.js
@@ -254,4 +254,8 @@ export default function registerHandlebarsHelpers() {
 
     return result;
   });
+
+  Handlebars.registerHelper("hideSkillTooltips", () => {
+    return game.settings.get("deltagreen", "hideSkillTooltips");
+  });
 }

--- a/module/settings.js
+++ b/module/settings.js
@@ -312,6 +312,16 @@ export default function registerSystemSettings() {
     default: false,
   });
 
+  game.settings.register("deltagreen", "hideSkillTooltips", {
+    name: game.i18n.localize("DG.Settings.hideSkillTooltips.name"),
+    hint: game.i18n.localize("DG.Settings.hideSkillTooltips.hint"),
+    scope: "client",
+    config: true,
+    requiresReload: true,
+    type: Boolean,
+    default: false,
+  });
+
   // obsolete - will be removed at some point
   game.settings.register("deltagreen", "characterSheetFont", {
     name: "World Font Choice",

--- a/module/settings.js
+++ b/module/settings.js
@@ -1,5 +1,6 @@
 /* eslint-disable max-classes-per-file */
 import DG, { BASE_TEMPLATE_PATH } from "./config.js";
+import DGActorSheet from "./sheets/base-actor-sheet.js";
 
 const { ApplicationV2, HandlebarsApplicationMixin } = foundry.applications.api;
 
@@ -317,9 +318,15 @@ export default function registerSystemSettings() {
     hint: game.i18n.localize("DG.Settings.hideSkillTooltips.hint"),
     scope: "client",
     config: true,
-    requiresReload: true,
     type: Boolean,
     default: false,
+    onChange: () => {
+      foundry.applications.instances.forEach((app) => {
+        if (app instanceof DGActorSheet) {
+          app.render();
+        }
+      });
+    },
   });
 
   // obsolete - will be removed at some point

--- a/module/sheets/base-actor-sheet.js
+++ b/module/sheets/base-actor-sheet.js
@@ -399,8 +399,7 @@ export default class DGActorSheet extends DGSheetMixin(ActorSheetV2) {
    * @returns {void}
    */
   _prepareSkillTooltips() {
-    const skillsWithTooltips = [];
-    for (const [_, skill] of Object.entries(this.actor.system.sortedSkills)) {
+    for (const skill of Object.values(this.actor.system.sortedSkills)) {
       skill.tooltip = game.i18n.localize(`DG.Skills.Tooltip.${skill.key}`);
       if (!skill.proficiency) {
         skill.tooltip = skill.tooltip.concat(
@@ -409,9 +408,7 @@ export default class DGActorSheet extends DGSheetMixin(ActorSheetV2) {
           game.i18n.localize("DG.Tooltip.CannotRollSkillLabel"),
         );
       }
-      skillsWithTooltips.push(skill);
     }
-    this.actor.system.sortedSkills = skillsWithTooltips;
   }
 
   /**

--- a/module/sheets/base-actor-sheet.js
+++ b/module/sheets/base-actor-sheet.js
@@ -83,6 +83,9 @@ export default class DGActorSheet extends DGSheetMixin(ActorSheetV2) {
     this._sortSkills();
     this._sortCustomSkills();
 
+    // Setup tooltips
+    this._prepareSkillTooltips();
+
     // Set sanity block per actor type.
     context.sanityInputs = await foundry.applications.handlebars.renderTemplate(
       `${DGActorSheet.TEMPLATE_PATH}/partials/sanity-${this.actor.type}.html`,
@@ -388,6 +391,27 @@ export default class DGActorSheet extends DGSheetMixin(ActorSheetV2) {
     } else {
       this.actor.system.sortedCustomSkills = sortedCustomSkills;
     }
+  }
+
+  /**
+   * Sets up the list of sorted skills with their respective tooltips.
+   *
+   * @returns {void}
+   */
+  _prepareSkillTooltips() {
+    const skillsWithTooltips = [];
+    for (const [_, skill] of Object.entries(this.actor.system.sortedSkills)) {
+      skill.tooltip = game.i18n.localize(`DG.Skills.Tooltip.${skill.key}`);
+      if (!skill.proficiency) {
+        skill.tooltip = skill.tooltip.concat(
+          skill.tooltip,
+          "<br><br>",
+          game.i18n.localize("DG.Tooltip.CannotRollSkillLabel"),
+        );
+      }
+      skillsWithTooltips.push(skill);
+    }
+    this.actor.system.sortedSkills = skillsWithTooltips;
   }
 
   /**

--- a/module/sheets/base-actor-sheet.js
+++ b/module/sheets/base-actor-sheet.js
@@ -83,8 +83,16 @@ export default class DGActorSheet extends DGSheetMixin(ActorSheetV2) {
     this._sortSkills();
     this._sortCustomSkills();
 
-    // Setup tooltips
-    this._prepareSkillTooltips();
+    // Wether to hide skill tooltips
+    context.hideSkillTooltips = game.settings.get(
+      "deltagreen",
+      "hideSkillTooltips",
+    );
+
+    if (!context.hideSkillTooltips) {
+      // Setup tooltips
+      this._prepareSkillTooltips();
+    }
 
     // Set sanity block per actor type.
     context.sanityInputs = await foundry.applications.handlebars.renderTemplate(

--- a/templates/actor/parts/skills-tab.html
+++ b/templates/actor/parts/skills-tab.html
@@ -24,7 +24,10 @@
                        data-key="{{skill.key}}"
                        data-rolltype="skill"
                        for="system.skills.{{skill.key}}.value"
-                       data-tooltip="{{concat (localize (concat 'DG.Skills.Tooltip.' skill.key)) '<br><br>' (localize (ifThen skill.proficiency 'DG.Tooltip.SkillLabel' 'DG.Tooltip.CannotRollSkillLabel')) }}">
+                       {{#unless (hideSkillTooltips) }}
+                         data-tooltip="{{concat (localize (concat 'DG.Skills.Tooltip.' skill.key)) '<br><br>' (localize (ifThen skill.proficiency 'DG.Tooltip.SkillLabel' 'DG.Tooltip.CannotRollSkillLabel')) }}"
+                       {{/unless }}
+                >
                     {{localizeWithFallback (concat "DG.Skills." skill.key) skill.label }}
                     <i class="fas fa-dice"></i>
                 </label>

--- a/templates/actor/parts/skills-tab.html
+++ b/templates/actor/parts/skills-tab.html
@@ -25,7 +25,7 @@
                        data-rolltype="skill"
                        for="system.skills.{{skill.key}}.value"
                        {{#unless (hideSkillTooltips) }}
-                         data-tooltip="{{concat (localize (concat 'DG.Skills.Tooltip.' skill.key)) '<br><br>' (localize (ifThen skill.proficiency 'DG.Tooltip.SkillLabel' 'DG.Tooltip.CannotRollSkillLabel')) }}"
+                       data-tooltip="{{ skill.tooltip }}"
                        {{/unless }}
                 >
                     {{localizeWithFallback (concat "DG.Skills." skill.key) skill.label }}

--- a/templates/actor/parts/skills-tab.html
+++ b/templates/actor/parts/skills-tab.html
@@ -24,7 +24,7 @@
                        data-key="{{skill.key}}"
                        data-rolltype="skill"
                        for="system.skills.{{skill.key}}.value"
-                       {{#unless (hideSkillTooltips) }}
+                       {{#unless ../hideSkillTooltips }}
                        data-tooltip="{{ skill.tooltip }}"
                        {{/unless }}
                 >


### PR DESCRIPTION
## Checklist

<!-- Check one or more: -->

- [x] This is meant for the next release.
- [x] This is meant for a hotfix.
- [ ] This is a Build System change.
- [ ] This needs more reviewers than normal
- [ ] This intentionally introduces regressions that will be addressed later.
- [ ] The change will require updates to the documentation.
- [ ] Please do not send commits here without coordinating closely with the owner.

## What does this PR do?

<!-- Briefly describe the purpose of the PR and what it changes. -->
Adds the "Hide Skill Tooltips" system setting to allow clients to toggle display of skill tooltips in sheets.
Gets rid of the "Click to roll.." string in every rollable skill tooltip.

## How to Test

<!-- List steps to test the feature or fix. Include any setup instructions. -->

1. In the agent sheet, hover a skill and see the tooltip
2. In settings, check "Hide Skill Tooltips"
3. After reloading, hover a skill in a sheet -> no more tooltips

## Related Issue(s)

Closes #255, #252

## Future Work

<!-- Describe any follow-up work, improvements, or additional features related to this PR. -->
