### PR TITLE
fix(#259): add hidden sanity agent template

### DIFF
--- a/templates/actor/partials/sanity-agent.html
+++ b/templates/actor/partials/sanity-agent.html
@@ -1,3 +1,16 @@
+{{#if (keepSanityPrivate)}}
+<input class="centered"
+       type="text"
+       name="system.sanity.value"
+       value="???"
+       readonly
+       data-dtype="Number" />
+<span>/</span>
+<div class="max-resource-value"
+     data-tooltip="{{localize 'DG.Tooltip.MaximumSanity'}}">
+    <div>???</div>
+</div>
+{{else}}
 <input class="centered
               {{#if actor.system.sanity.breakingPointHit }}
                   breaking-point-hit{{/if }}"
@@ -11,3 +24,4 @@
      data-tooltip="{{localize 'DG.Tooltip.MaximumSanity'}}">
     <div>{{numberFormat actor.system.sanity.max decimals=0 sign=false}}</div>
 </div>
+{{/if}}


### PR DESCRIPTION
## Checklist

<!-- Check one or more: -->

- [x] This is meant for the next release.
- [ ] This is meant for a hotfix.
- [ ] This is a Build System change.
- [ ] This needs more reviewers than normal
- [ ] This intentionally introduces regressions that will be addressed later.
- [ ] The change will require updates to the documentation.
- [ ] Please do not send commits here without coordinating closely with the owner.

## What does this PR do?

<!-- Briefly describe the purpose of the PR and what it changes. -->
Handles the `keepSanityPrivate` setting in agent sheets by obfuscating current and maximum SAN values. 

## How to Test

<!-- List steps to test the feature or fix. Include any setup instructions. -->

1. Toggle the setting
2. Log in as the owner of an actor sheet without GM permissions
3. Check the sanity values

## Related Issue(s)

<!-- Link to issues this PR closes/fixes. Use GitHub auto-closing keywords if appropriate. -->

Closes #259 

## Future Work

<!-- Describe any follow-up work, improvements, or additional features related to this PR. -->
