### PR TITLE
fix(#272): hook into renderChatMessageHTML for skill fail rollbacks

### DIFF
--- a/module/deltagreen.js
+++ b/module/deltagreen.js
@@ -214,7 +214,7 @@ Hooks.on("renderGamePause", function (_, html, options) {
   }
 });
 
-Hooks.on("renderChatLog", async (app, element, context, options) => {
+Hooks.on("renderChatMessageHTML", async (app, element, context, options) => {
   element.addEventListener("click", (event) => {
     const btnWithAction = event.target.closest("button[data-action]");
     const message = event.target.closest("li[data-message-id]");


### PR DESCRIPTION
## Checklist

<!-- Check one or more: -->

- [x] This is meant for the next release.
- [ ] This is meant for a hotfix.
- [ ] This is a Build System change.
- [ ] This needs more reviewers than normal
- [ ] This intentionally introduces regressions that will be addressed later.
- [ ] The change will require updates to the documentation.
- [ ] Please do not send commits here without coordinating closely with the owner.

## What does this PR do?

<!-- Briefly describe the purpose of the PR and what it changes. -->
Changes the hook used to setup the skill failure rollback button event listeners from `renderChatLog` to `renderChatMessageHTML` which is fired for both chat bubbles and regular chat log messages.
## How to Test

<!-- List steps to test the feature or fix. Include any setup instructions. -->

1. Enable Auto-Mark Skill Failures
2. Fail a check
3. Rollback from the chat bubble
4. Fail another check
5. Rollback from the chat log

## Related Issue(s)

<!-- Link to issues this PR closes/fixes. Use GitHub auto-closing keywords if appropriate. -->

Closes #272 

## Future Work

<!-- Describe any follow-up work, improvements, or additional features related to this PR. -->
