### PR TITLE
fix (#269): calc unnatural max wp and health

### DIFF
--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -86,7 +86,7 @@ export default class DeltaGreenActor extends Actor {
       proficiency: 99 - system.sanity.value,
       cannotBeImprovedByFailure: true,
       failure: false,
-    };    
+    };
 
     if (system.skills.ritual.proficiency > 99) {
       system.skills.ritual.proficiency = 99;
@@ -135,9 +135,19 @@ export default class DeltaGreenActor extends Actor {
     const { system } = actor;
 
     // Loop through ability scores, and add their modifiers to our sheet output.
-    for (const [key, statistic] of Object.entries(system.statistics)) {
+    for (const statistic of Object.values(system.statistics)) {
       // the x5 is just whatever the raw statistic is x 5 to turn it into a d100 percentile
       statistic.x5 = statistic.value * 5;
+    }
+
+    system.wp.max = system.statistics.pow.value;
+
+    try {
+      system.health.max = Math.ceil(
+        (system.statistics.con.value + system.statistics.str.value) / 2,
+      );
+    } catch {
+      system.health.max = 10;
     }
 
     // calculate total armor rating
@@ -152,7 +162,7 @@ export default class DeltaGreenActor extends Actor {
 
     system.health.protection = protection;
 
-    for (const [_key, skill] of Object.entries(system.skills)) {
+    for (const skill of Object.values(system.skills)) {
       skill.targetProficiency = skill.proficiency;
     }
   }
@@ -179,7 +189,7 @@ export default class DeltaGreenActor extends Actor {
       proficiency: 99 - system.sanity.value,
       cannotBeImprovedByFailure: true,
       failure: false,
-    };    
+    };
 
     if (system.skills.ritual.proficiency > 99) {
       system.skills.ritual.proficiency = 99;


### PR DESCRIPTION
## Checklist

<!-- Check one or more: -->

- [x] This is meant for the next release.
- [ ] This is meant for a hotfix.
- [ ] This is a Build System change.
- [ ] This needs more reviewers than normal
- [ ] This intentionally introduces regressions that will be addressed later.
- [ ] The change will require updates to the documentation.
- [ ] Please do not send commits here without coordinating closely with the owner.

## What does this PR do?

Adds some logic to calculate the max wp and health on unnaturals.

## How to Test

<!-- List steps to test the feature or fix. Include any setup instructions. -->

1. Create a unnatural
2. Update STR and/or CON values
3. Max health should update using the formula => (STR + CON)/2 rounded up
4. Update POW value
5. Max WP should update with the POW value

## Related Issue(s)

<!-- Link to issues this PR closes/fixes. Use GitHub auto-closing keywords if appropriate. -->

Closes #269