### PR TITLE
Add Professions compendia to system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ packs/operation-code-name-generator-macro
 packs/operation-code-name-generator-macro*
 packs/pregens
 packs/pregens*
+packs/professions
+packs/professions*
 deltagreen.lock
 
 # Ignore npm modules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release/Patch Notes
 
+## Unrelased
+
+### **Features:**
+
+- [#436](https://github.com/deltagreen-foundryvtt/delta-green-foundry-vtt-system/issues/436) Add professions compendia (props to @Vogliadicone for doing the hard part!)
+
 ## Version 2.0.1 - 2026-08-10
 
 ### **Bug Fixes:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release/Patch Notes
 
-## Unrelased
+## Unreleased
 
 ### **Features:**
 

--- a/packs/source/professions/Anthropologist_or_Historian__Anthropology__md5gUq3lBj9CkZLR.json
+++ b/packs/source/professions/Anthropologist_or_Historian__Anthropology__md5gUq3lBj9CkZLR.json
@@ -1,0 +1,58 @@
+{
+  "folder": null,
+  "name": "Anthropologist or Historian (Anthropology)",
+  "type": "profession",
+  "_id": "md5gUq3lBj9CkZLR",
+  "img": "systems/deltagreen/assets/icons/person-black-bg.svg",
+  "system": {
+    "description": "<p>See Page 20 of the Agent's Handbook.</p>",
+    "bonds": 4,
+    "automaticSkills": {
+      "anthropology": 50,
+      "bureaucracy": 40,
+      "typed:ForeignLanguage:GTHrglZg": 50,
+      "typed:ForeignLanguage:BDuPpCMu": 40,
+      "history": 60,
+      "occult": 40,
+      "persuade": 40
+    },
+    "automaticSkillMeta": {
+      "typed:ForeignLanguage:GTHrglZg": {
+        "chooseOne": true
+      },
+      "typed:ForeignLanguage:BDuPpCMu": {
+        "chooseOne": true
+      }
+    },
+    "optionSkills": {
+      "optionPicks": 0,
+      "anthropology": 40,
+      "archeology": 40,
+      "humint": 50,
+      "navigate": 50,
+      "ride": 50,
+      "search": 60,
+      "survival": 50
+    },
+    "optionSkillMeta": {}
+  },
+  "effects": [],
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "deltagreen",
+    "systemVersion": "2.0.0-beta3",
+    "createdTime": 1782382835926,
+    "modifiedTime": 1782382835938,
+    "lastModifiedBy": "961R6wJiqwnS0zD3",
+    "exportSource": null,
+    "compendiumSource": null,
+    "duplicateSource": null
+  },
+  "ownership": {
+    "default": 0,
+    "961R6wJiqwnS0zD3": 3
+  },
+  "sort": 0,
+  "_key": "!items!md5gUq3lBj9CkZLR"
+}

--- a/packs/source/professions/Anthropologist_or_Historian__Anthropology__md5gUq3lBj9CkZLR.json
+++ b/packs/source/professions/Anthropologist_or_Historian__Anthropology__md5gUq3lBj9CkZLR.json
@@ -25,8 +25,7 @@
       }
     },
     "optionSkills": {
-      "optionPicks": 0,
-      "anthropology": 40,
+      "optionPicks": 2,
       "archeology": 40,
       "humint": 50,
       "navigate": 50,

--- a/packs/source/professions/Anthropologist_or_Historian__Archeology__ZFTI2GzBvzwdkuzq.json
+++ b/packs/source/professions/Anthropologist_or_Historian__Archeology__ZFTI2GzBvzwdkuzq.json
@@ -1,0 +1,58 @@
+{
+  "folder": null,
+  "name": "Anthropologist or Historian (Archeology)",
+  "type": "profession",
+  "img": "systems/deltagreen/assets/icons/person-black-bg.svg",
+  "system": {
+    "description": "<p>See Page 20 of the Agent's Handbook.</p>",
+    "bonds": 4,
+    "automaticSkills": {
+      "bureaucracy": 40,
+      "typed:ForeignLanguage:GTHrglZg": 50,
+      "typed:ForeignLanguage:BDuPpCMu": 40,
+      "history": 60,
+      "occult": 40,
+      "persuade": 40,
+      "archeology": 50
+    },
+    "automaticSkillMeta": {
+      "typed:ForeignLanguage:GTHrglZg": {
+        "chooseOne": true
+      },
+      "typed:ForeignLanguage:BDuPpCMu": {
+        "chooseOne": true
+      }
+    },
+    "optionSkills": {
+      "optionPicks": 0,
+      "anthropology": 40,
+      "archeology": 40,
+      "humint": 50,
+      "navigate": 50,
+      "ride": 50,
+      "search": 60,
+      "survival": 50
+    },
+    "optionSkillMeta": {}
+  },
+  "effects": [],
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "deltagreen",
+    "systemVersion": "2.0.0-beta3",
+    "createdTime": 1782382835927,
+    "modifiedTime": 1782382835939,
+    "lastModifiedBy": "961R6wJiqwnS0zD3",
+    "exportSource": null,
+    "compendiumSource": null,
+    "duplicateSource": null
+  },
+  "_id": "ZFTI2GzBvzwdkuzq",
+  "ownership": {
+    "default": 0,
+    "961R6wJiqwnS0zD3": 3
+  },
+  "sort": 0,
+  "_key": "!items!ZFTI2GzBvzwdkuzq"
+}

--- a/packs/source/professions/Anthropologist_or_Historian__Archeology__ZFTI2GzBvzwdkuzq.json
+++ b/packs/source/professions/Anthropologist_or_Historian__Archeology__ZFTI2GzBvzwdkuzq.json
@@ -24,9 +24,8 @@
       }
     },
     "optionSkills": {
-      "optionPicks": 0,
+      "optionPicks": 2,
       "anthropology": 40,
-      "archeology": 40,
       "humint": 50,
       "navigate": 50,
       "ride": 50,

--- a/packs/source/professions/Computer_Scientist_or_Engineer_KNrTM4jLomNSTSCh.json
+++ b/packs/source/professions/Computer_Scientist_or_Engineer_KNrTM4jLomNSTSCh.json
@@ -1,0 +1,60 @@
+{
+  "folder": null,
+  "name": "Computer Scientist or Engineer",
+  "type": "profession",
+  "_id": "KNrTM4jLomNSTSCh",
+  "img": "systems/deltagreen/assets/icons/person-black-bg.svg",
+  "system": {
+    "description": "<p>See Page 21 of the Agent's Handbook.</p>",
+    "bonds": 3,
+    "automaticSkills": {
+      "computer_science": 60,
+      "Craft (Electrician)": 30,
+      "Craft (Mechanic)": 30,
+      "Craft (Microelectronics)": 40,
+      "Science (Mathematics)": 40,
+      "sigint": 40
+    },
+    "automaticSkillMeta": {},
+    "optionSkills": {
+      "optionPicks": 4,
+      "accounting": 50,
+      "bureaucracy": 50,
+      "typed:Craft:CQseZ4mK": 40,
+      "typed:ForeignLanguage:LOHNweby": 40,
+      "heavy_machiner": 50,
+      "law": 40,
+      "typed:Science:n2M8FiNY": 40
+    },
+    "optionSkillMeta": {
+      "typed:Craft:CQseZ4mK": {
+        "chooseOne": true
+      },
+      "typed:ForeignLanguage:LOHNweby": {
+        "chooseOne": true
+      },
+      "typed:Science:n2M8FiNY": {
+        "chooseOne": true
+      }
+    }
+  },
+  "effects": [],
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "deltagreen",
+    "systemVersion": "2.0.0-beta3",
+    "createdTime": 1782382835927,
+    "modifiedTime": 1782382835939,
+    "lastModifiedBy": "961R6wJiqwnS0zD3",
+    "exportSource": null,
+    "compendiumSource": null,
+    "duplicateSource": null
+  },
+  "ownership": {
+    "default": 0,
+    "961R6wJiqwnS0zD3": 3
+  },
+  "sort": 0,
+  "_key": "!items!KNrTM4jLomNSTSCh"
+}

--- a/packs/source/professions/Criminal_tZ4CqlBHXhBOtZUm.json
+++ b/packs/source/professions/Criminal_tZ4CqlBHXhBOtZUm.json
@@ -1,0 +1,61 @@
+{
+  "folder": null,
+  "name": "Criminal",
+  "type": "profession",
+  "_id": "tZ4CqlBHXhBOtZUm",
+  "img": "systems/deltagreen/assets/icons/person-black-bg.svg",
+  "system": {
+    "description": "<p>See Page 23 of the Agent's Handbook.</p>",
+    "bonds": 4,
+    "automaticSkills": {
+      "alertness": 50,
+      "athletics": 50,
+      "criminology": 60,
+      "dodge": 40,
+      "drive": 50,
+      "firearms": 40,
+      "law": 20,
+      "melee_weapons": 40,
+      "persuade": 50,
+      "stealth": 50,
+      "unarmed_combat": 50
+    },
+    "automaticSkillMeta": {},
+    "optionSkills": {
+      "optionPicks": 2,
+      "Craft (Locksmithing)": 40,
+      "demolitions": 40,
+      "disguise": 50,
+      "typed:ForeignLanguage:HsAiTuog": 40,
+      "forensics": 40,
+      "humint": 50,
+      "navigate": 50,
+      "occult": 50,
+      "pharmacy": 40
+    },
+    "optionSkillMeta": {
+      "typed:ForeignLanguage:HsAiTuog": {
+        "chooseOne": true
+      }
+    }
+  },
+  "effects": [],
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "deltagreen",
+    "systemVersion": "2.0.0-beta3",
+    "createdTime": 1782382835928,
+    "modifiedTime": 1782382835939,
+    "lastModifiedBy": "961R6wJiqwnS0zD3",
+    "exportSource": null,
+    "compendiumSource": null,
+    "duplicateSource": null
+  },
+  "ownership": {
+    "default": 0,
+    "961R6wJiqwnS0zD3": 3
+  },
+  "sort": 0,
+  "_key": "!items!tZ4CqlBHXhBOtZUm"
+}

--- a/packs/source/professions/Federal_Agent_0PMHDVKh8plI1FIs.json
+++ b/packs/source/professions/Federal_Agent_0PMHDVKh8plI1FIs.json
@@ -1,0 +1,56 @@
+{
+  "folder": null,
+  "name": "Federal Agent",
+  "type": "profession",
+  "_id": "0PMHDVKh8plI1FIs",
+  "img": "systems/deltagreen/assets/icons/person-black-bg.svg",
+  "system": {
+    "description": "<p>See Page 21 of the Agent's Handbook.</p>",
+    "bonds": 3,
+    "automaticSkills": {
+      "alertness": 50,
+      "bureaucracy": 40,
+      "criminology": 50,
+      "drive": 50,
+      "firearms": 50,
+      "humint": 60,
+      "law": 30,
+      "persuade": 50,
+      "search": 50,
+      "unarmed_combat": 60
+    },
+    "automaticSkillMeta": {},
+    "optionSkills": {
+      "optionPicks": 1,
+      "accounting": 60,
+      "computer_science": 50,
+      "typed:ForeignLanguage:cSvjqgRT": 50,
+      "heavy_weapons": 50,
+      "pharmacy": 50
+    },
+    "optionSkillMeta": {
+      "typed:ForeignLanguage:cSvjqgRT": {
+        "chooseOne": true
+      }
+    }
+  },
+  "effects": [],
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "deltagreen",
+    "systemVersion": "2.0.0-beta3",
+    "createdTime": 1782382835929,
+    "modifiedTime": 1782382835940,
+    "lastModifiedBy": "961R6wJiqwnS0zD3",
+    "exportSource": null,
+    "compendiumSource": null,
+    "duplicateSource": null
+  },
+  "ownership": {
+    "default": 0,
+    "961R6wJiqwnS0zD3": 3
+  },
+  "sort": 0,
+  "_key": "!items!0PMHDVKh8plI1FIs"
+}

--- a/packs/source/professions/Firefighter_xfra1qqbkVHP45pZ.json
+++ b/packs/source/professions/Firefighter_xfra1qqbkVHP45pZ.json
@@ -1,0 +1,48 @@
+{
+  "folder": null,
+  "name": "Firefighter",
+  "type": "profession",
+  "_id": "xfra1qqbkVHP45pZ",
+  "img": "systems/deltagreen/assets/icons/person-black-bg.svg",
+  "system": {
+    "description": "<p>See Page 23 of the Agent's Handbook.</p>",
+    "bonds": 3,
+    "automaticSkills": {
+      "alertness": 50,
+      "athletics": 60,
+      "Craft (Electrician)": 40,
+      "Craft (Mechanic)": 40,
+      "demolitions": 50,
+      "drive": 50,
+      "first_aid": 50,
+      "forensics": 40,
+      "heavy_machiner": 50,
+      "navigate": 50,
+      "search": 40
+    },
+    "automaticSkillMeta": {},
+    "optionSkills": {
+      "optionPicks": 0
+    },
+    "optionSkillMeta": {}
+  },
+  "effects": [],
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "deltagreen",
+    "systemVersion": "2.0.0-beta3",
+    "createdTime": 1782382835930,
+    "modifiedTime": 1782382835940,
+    "lastModifiedBy": "961R6wJiqwnS0zD3",
+    "exportSource": null,
+    "compendiumSource": null,
+    "duplicateSource": null
+  },
+  "ownership": {
+    "default": 0,
+    "961R6wJiqwnS0zD3": 3
+  },
+  "sort": 0,
+  "_key": "!items!xfra1qqbkVHP45pZ"
+}

--- a/packs/source/professions/Foreign_Service_Officer_2MPrfKHNiYnub74A.json
+++ b/packs/source/professions/Foreign_Service_Officer_2MPrfKHNiYnub74A.json
@@ -1,0 +1,57 @@
+{
+  "folder": null,
+  "name": "Foreign Service Officer",
+  "type": "profession",
+  "_id": "2MPrfKHNiYnub74A",
+  "img": "systems/deltagreen/assets/icons/person-black-bg.svg",
+  "system": {
+    "description": "<p>See Page 23 of the Agent's Handbook.</p>",
+    "bonds": 3,
+    "automaticSkills": {
+      "accounting": 40,
+      "anthropology": 40,
+      "bureaucracy": 60,
+      "typed:ForeignLanguage:5KmWvvyL": 50,
+      "typed:ForeignLanguage:HBosCZhb": 50,
+      "typed:ForeignLanguage:LDA7AvfM": 40,
+      "history": 40,
+      "humint": 50,
+      "law": 40,
+      "persuade": 50
+    },
+    "automaticSkillMeta": {
+      "typed:ForeignLanguage:5KmWvvyL": {
+        "chooseOne": true
+      },
+      "typed:ForeignLanguage:HBosCZhb": {
+        "chooseOne": true
+      },
+      "typed:ForeignLanguage:LDA7AvfM": {
+        "chooseOne": true
+      }
+    },
+    "optionSkills": {
+      "optionPicks": 0
+    },
+    "optionSkillMeta": {}
+  },
+  "effects": [],
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "deltagreen",
+    "systemVersion": "2.0.0-beta3",
+    "createdTime": 1782382835930,
+    "modifiedTime": 1782382835940,
+    "lastModifiedBy": "961R6wJiqwnS0zD3",
+    "exportSource": null,
+    "compendiumSource": null,
+    "duplicateSource": null
+  },
+  "ownership": {
+    "default": 0,
+    "961R6wJiqwnS0zD3": 3
+  },
+  "sort": 0,
+  "_key": "!items!2MPrfKHNiYnub74A"
+}

--- a/packs/source/professions/Intelligence_Analyst_pPZVbu7aXUirCdZs.json
+++ b/packs/source/professions/Intelligence_Analyst_pPZVbu7aXUirCdZs.json
@@ -1,0 +1,57 @@
+{
+  "folder": null,
+  "name": "Intelligence Analyst",
+  "type": "profession",
+  "_id": "pPZVbu7aXUirCdZs",
+  "img": "systems/deltagreen/assets/icons/person-black-bg.svg",
+  "system": {
+    "description": "<p>See Page 24 of the Agent's Handbook.</p>",
+    "bonds": 3,
+    "automaticSkills": {
+      "anthropology": 40,
+      "bureaucracy": 50,
+      "computer_science": 40,
+      "criminology": 40,
+      "typed:ForeignLanguage:3wuG9i1B": 50,
+      "typed:ForeignLanguage:BXNOusYj": 50,
+      "typed:ForeignLanguage:VC1P4AtU": 40,
+      "history": 40,
+      "humint": 50,
+      "sigint": 40
+    },
+    "automaticSkillMeta": {
+      "typed:ForeignLanguage:3wuG9i1B": {
+        "chooseOne": true
+      },
+      "typed:ForeignLanguage:BXNOusYj": {
+        "chooseOne": true
+      },
+      "typed:ForeignLanguage:VC1P4AtU": {
+        "chooseOne": true
+      }
+    },
+    "optionSkills": {
+      "optionPicks": 0
+    },
+    "optionSkillMeta": {}
+  },
+  "effects": [],
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "deltagreen",
+    "systemVersion": "2.0.0-beta3",
+    "createdTime": 1782382835931,
+    "modifiedTime": 1782382835940,
+    "lastModifiedBy": "961R6wJiqwnS0zD3",
+    "exportSource": null,
+    "compendiumSource": null,
+    "duplicateSource": null
+  },
+  "ownership": {
+    "default": 0,
+    "961R6wJiqwnS0zD3": 3
+  },
+  "sort": 0,
+  "_key": "!items!pPZVbu7aXUirCdZs"
+}

--- a/packs/source/professions/Intelligence_Case_Officer_W70c4NfKo19aKU48.json
+++ b/packs/source/professions/Intelligence_Case_Officer_W70c4NfKo19aKU48.json
@@ -1,0 +1,57 @@
+{
+  "folder": null,
+  "name": "Intelligence Case Officer",
+  "type": "profession",
+  "_id": "W70c4NfKo19aKU48",
+  "img": "systems/deltagreen/assets/icons/person-black-bg.svg",
+  "system": {
+    "description": "<p>See Page 24 of the Agent's Handbook.</p>",
+    "bonds": 2,
+    "automaticSkills": {
+      "alertness": 50,
+      "bureaucracy": 40,
+      "criminology": 50,
+      "disguise": 50,
+      "drive": 40,
+      "firearms": 40,
+      "typed:ForeignLanguage:7DRxXCZJ": 50,
+      "typed:ForeignLanguage:YdUdgmkc": 40,
+      "humint": 60,
+      "persuade": 60,
+      "sigint": 40,
+      "stealth": 50,
+      "unarmed_combat": 50
+    },
+    "automaticSkillMeta": {
+      "typed:ForeignLanguage:7DRxXCZJ": {
+        "chooseOne": true
+      },
+      "typed:ForeignLanguage:YdUdgmkc": {
+        "chooseOne": true
+      }
+    },
+    "optionSkills": {
+      "optionPicks": 0
+    },
+    "optionSkillMeta": {}
+  },
+  "effects": [],
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "deltagreen",
+    "systemVersion": "2.0.0-beta3",
+    "createdTime": 1782382835931,
+    "modifiedTime": 1782382835940,
+    "lastModifiedBy": "961R6wJiqwnS0zD3",
+    "exportSource": null,
+    "compendiumSource": null,
+    "duplicateSource": null
+  },
+  "ownership": {
+    "default": 0,
+    "961R6wJiqwnS0zD3": 3
+  },
+  "sort": 0,
+  "_key": "!items!W70c4NfKo19aKU48"
+}

--- a/packs/source/professions/Lawyer_or_Business_Executive_lvQCWcd7R1VFpMuC.json
+++ b/packs/source/professions/Lawyer_or_Business_Executive_lvQCWcd7R1VFpMuC.json
@@ -1,0 +1,50 @@
+{
+  "folder": null,
+  "name": "Lawyer or Business Executive",
+  "type": "profession",
+  "_id": "lvQCWcd7R1VFpMuC",
+  "img": "systems/deltagreen/assets/icons/person-black-bg.svg",
+  "system": {
+    "description": "<p>See Page 24 of the Agent's Handbook.</p>",
+    "bonds": 4,
+    "automaticSkills": {
+      "accounting": 50,
+      "bureaucracy": 50,
+      "humint": 40,
+      "persuade": 60
+    },
+    "automaticSkillMeta": {},
+    "optionSkills": {
+      "optionPicks": 4,
+      "computer_science": 50,
+      "criminology": 60,
+      "typed:ForeignLanguage:U8k4UxgF": 50,
+      "law": 50,
+      "pharmacy": 50
+    },
+    "optionSkillMeta": {
+      "typed:ForeignLanguage:U8k4UxgF": {
+        "chooseOne": true
+      }
+    }
+  },
+  "effects": [],
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "deltagreen",
+    "systemVersion": "2.0.0-beta3",
+    "createdTime": 1782382835932,
+    "modifiedTime": 1782382835941,
+    "lastModifiedBy": "961R6wJiqwnS0zD3",
+    "exportSource": null,
+    "compendiumSource": null,
+    "duplicateSource": null
+  },
+  "ownership": {
+    "default": 0,
+    "961R6wJiqwnS0zD3": 3
+  },
+  "sort": 0,
+  "_key": "!items!lvQCWcd7R1VFpMuC"
+}

--- a/packs/source/professions/Media_Specialist_20raQeM2AIK0hllA.json
+++ b/packs/source/professions/Media_Specialist_20raQeM2AIK0hllA.json
@@ -1,0 +1,69 @@
+{
+  "folder": null,
+  "name": "Media Specialist",
+  "type": "profession",
+  "_id": "20raQeM2AIK0hllA",
+  "img": "systems/deltagreen/assets/icons/person-black-bg.svg",
+  "system": {
+    "description": "<p>See Page 24 of the Agent's Handbook.</p>",
+    "bonds": 4,
+    "automaticSkills": {
+      "typed:Art:9FGlk18y": 60,
+      "history": 40,
+      "humint": 40,
+      "persuade": 50
+    },
+    "automaticSkillMeta": {
+      "typed:Art:9FGlk18y": {
+        "chooseOne": true
+      }
+    },
+    "optionSkills": {
+      "optionPicks": 5,
+      "anthropology": 40,
+      "archeology": 40,
+      "typed:Art:jiWgggHu": 40,
+      "bureaucracy": 50,
+      "computer_science": 40,
+      "criminology": 50,
+      "typed:ForeignLanguage:qgtHFHdc": 40,
+      "law": 40,
+      "typed:MilitaryScience:SdmeUKSF": 40,
+      "occult": 50,
+      "typed:Science:MCr9wIQg": 40
+    },
+    "optionSkillMeta": {
+      "typed:Art:jiWgggHu": {
+        "chooseOne": true
+      },
+      "typed:ForeignLanguage:qgtHFHdc": {
+        "chooseOne": true
+      },
+      "typed:MilitaryScience:SdmeUKSF": {
+        "chooseOne": true
+      },
+      "typed:Science:MCr9wIQg": {
+        "chooseOne": true
+      }
+    }
+  },
+  "effects": [],
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "deltagreen",
+    "systemVersion": "2.0.0-beta3",
+    "createdTime": 1782382835933,
+    "modifiedTime": 1782382835941,
+    "lastModifiedBy": "961R6wJiqwnS0zD3",
+    "exportSource": null,
+    "compendiumSource": null,
+    "duplicateSource": null
+  },
+  "ownership": {
+    "default": 0,
+    "961R6wJiqwnS0zD3": 3
+  },
+  "sort": 0,
+  "_key": "!items!20raQeM2AIK0hllA"
+}

--- a/packs/source/professions/Nurse_or_Paramedic_HLkrseugCuC1qLv7.json
+++ b/packs/source/professions/Nurse_or_Paramedic_HLkrseugCuC1qLv7.json
@@ -1,0 +1,50 @@
+{
+  "folder": null,
+  "name": "Nurse or Paramedic",
+  "type": "profession",
+  "_id": "HLkrseugCuC1qLv7",
+  "img": "systems/deltagreen/assets/icons/person-black-bg.svg",
+  "system": {
+    "description": "<p>See Page 25 of the Agent's Handbook.</p>",
+    "bonds": 4,
+    "automaticSkills": {
+      "alertness": 40,
+      "bureaucracy": 40,
+      "first_aid": 60,
+      "humint": 40,
+      "medicine": 40,
+      "persuade": 40,
+      "pharmacy": 40,
+      "Science (Biology)": 40
+    },
+    "automaticSkillMeta": {},
+    "optionSkills": {
+      "optionPicks": 2,
+      "drive": 60,
+      "forensics": 40,
+      "navigate": 50,
+      "psychotherapy": 50,
+      "search": 60
+    },
+    "optionSkillMeta": {}
+  },
+  "effects": [],
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "deltagreen",
+    "systemVersion": "2.0.0-beta3",
+    "createdTime": 1782382835933,
+    "modifiedTime": 1782382835941,
+    "lastModifiedBy": "961R6wJiqwnS0zD3",
+    "exportSource": null,
+    "compendiumSource": null,
+    "duplicateSource": null
+  },
+  "ownership": {
+    "default": 0,
+    "961R6wJiqwnS0zD3": 3
+  },
+  "sort": 0,
+  "_key": "!items!HLkrseugCuC1qLv7"
+}

--- a/packs/source/professions/Physician_dNu3mt3wTQ00TMsK.json
+++ b/packs/source/professions/Physician_dNu3mt3wTQ00TMsK.json
@@ -1,0 +1,52 @@
+{
+  "folder": null,
+  "name": "Physician",
+  "type": "profession",
+  "_id": "dNu3mt3wTQ00TMsK",
+  "img": "systems/deltagreen/assets/icons/person-black-bg.svg",
+  "system": {
+    "description": "<p>See Page 22 of the Agent's Handbook.</p>",
+    "bonds": 3,
+    "automaticSkills": {
+      "bureaucracy": 50,
+      "first_aid": 60,
+      "medicine": 60,
+      "persuade": 40,
+      "pharmacy": 50,
+      "Science (Biology)": 60,
+      "search": 40
+    },
+    "automaticSkillMeta": {},
+    "optionSkills": {
+      "optionPicks": 2,
+      "forensics": 50,
+      "psychotherapy": 60,
+      "typed:Science:iC63GBbu": 50,
+      "surgery": 50
+    },
+    "optionSkillMeta": {
+      "typed:Science:iC63GBbu": {
+        "chooseOne": true
+      }
+    }
+  },
+  "effects": [],
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "deltagreen",
+    "systemVersion": "2.0.0-beta3",
+    "createdTime": 1782382835934,
+    "modifiedTime": 1782382835941,
+    "lastModifiedBy": "961R6wJiqwnS0zD3",
+    "exportSource": null,
+    "compendiumSource": null,
+    "duplicateSource": null
+  },
+  "ownership": {
+    "default": 0,
+    "961R6wJiqwnS0zD3": 3
+  },
+  "sort": 0,
+  "_key": "!items!dNu3mt3wTQ00TMsK"
+}

--- a/packs/source/professions/Pilot_or_Sailor_P9duX0jjrm9wXyH5.json
+++ b/packs/source/professions/Pilot_or_Sailor_P9duX0jjrm9wXyH5.json
@@ -1,0 +1,63 @@
+{
+  "folder": null,
+  "name": "Pilot or Sailor",
+  "type": "profession",
+  "_id": "P9duX0jjrm9wXyH5",
+  "img": "systems/deltagreen/assets/icons/person-black-bg.svg",
+  "system": {
+    "description": "<p>See Page 25 of the Agent's Handbook.</p>",
+    "bonds": 3,
+    "automaticSkills": {
+      "alertness": 60,
+      "bureaucracy": 30,
+      "Craft (Electrician)": 40,
+      "Craft (Mechanic)": 40,
+      "navigate": 50,
+      "typed:Pilot:tgOhrg2a": 60,
+      "Science (Meteorology)": 40,
+      "swim": 40
+    },
+    "automaticSkillMeta": {
+      "typed:Pilot:tgOhrg2a": {
+        "chooseOne": true
+      }
+    },
+    "optionSkills": {
+      "optionPicks": 2,
+      "typed:ForeignLanguage:QHgvu0po": 50,
+      "typed:Pilot:X1LyIgyT": 50,
+      "heavy_weapons": 50,
+      "typed:MilitaryScience:UfLrfqi9": 50
+    },
+    "optionSkillMeta": {
+      "typed:ForeignLanguage:QHgvu0po": {
+        "chooseOne": true
+      },
+      "typed:Pilot:X1LyIgyT": {
+        "chooseOne": true
+      },
+      "typed:MilitaryScience:UfLrfqi9": {
+        "chooseOne": true
+      }
+    }
+  },
+  "effects": [],
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "deltagreen",
+    "systemVersion": "2.0.0-beta3",
+    "createdTime": 1782382835934,
+    "modifiedTime": 1782382835942,
+    "lastModifiedBy": "961R6wJiqwnS0zD3",
+    "exportSource": null,
+    "compendiumSource": null,
+    "duplicateSource": null
+  },
+  "ownership": {
+    "default": 0,
+    "961R6wJiqwnS0zD3": 3
+  },
+  "sort": 0,
+  "_key": "!items!P9duX0jjrm9wXyH5"
+}

--- a/packs/source/professions/Police_Officer_mnZU7OfZx38x7Fiw.json
+++ b/packs/source/professions/Police_Officer_mnZU7OfZx38x7Fiw.json
@@ -1,0 +1,54 @@
+{
+  "folder": null,
+  "name": "Police Officer",
+  "type": "profession",
+  "_id": "mnZU7OfZx38x7Fiw",
+  "img": "systems/deltagreen/assets/icons/person-black-bg.svg",
+  "system": {
+    "description": "<p>See Page 25 of the Agent's Handbook.</p>",
+    "bonds": 3,
+    "automaticSkills": {
+      "alertness": 60,
+      "bureaucracy": 40,
+      "criminology": 40,
+      "drive": 50,
+      "firearms": 40,
+      "first_aid": 30,
+      "humint": 50,
+      "law": 30,
+      "melee_weapons": 50,
+      "navigate": 40,
+      "persuade": 40,
+      "search": 40,
+      "unarmed_combat": 60
+    },
+    "automaticSkillMeta": {},
+    "optionSkills": {
+      "optionPicks": 1,
+      "forensics": 50,
+      "heavy_machiner": 60,
+      "heavy_weapons": 50,
+      "ride": 60
+    },
+    "optionSkillMeta": {}
+  },
+  "effects": [],
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "deltagreen",
+    "systemVersion": "2.0.0-beta3",
+    "createdTime": 1782382835936,
+    "modifiedTime": 1782382835942,
+    "lastModifiedBy": "961R6wJiqwnS0zD3",
+    "exportSource": null,
+    "compendiumSource": null,
+    "duplicateSource": null
+  },
+  "ownership": {
+    "default": 0,
+    "961R6wJiqwnS0zD3": 3
+  },
+  "sort": 0,
+  "_key": "!items!mnZU7OfZx38x7Fiw"
+}

--- a/packs/source/professions/Program_Manager_cjlhFhpvqMswe8lS.json
+++ b/packs/source/professions/Program_Manager_cjlhFhpvqMswe8lS.json
@@ -1,0 +1,63 @@
+{
+  "folder": null,
+  "name": "Program Manager",
+  "type": "profession",
+  "_id": "cjlhFhpvqMswe8lS",
+  "img": "systems/deltagreen/assets/icons/person-black-bg.svg",
+  "system": {
+    "description": "<p>See Page 25 of the Agent's Handbook.</p>",
+    "bonds": 4,
+    "automaticSkills": {
+      "accounting": 60,
+      "bureaucracy": 60,
+      "computer_science": 50,
+      "criminology": 30,
+      "typed:ForeignLanguage:iFHwRvVJ": 50,
+      "history": 40,
+      "law": 40,
+      "persuade": 50
+    },
+    "automaticSkillMeta": {
+      "typed:ForeignLanguage:iFHwRvVJ": {
+        "chooseOne": true
+      }
+    },
+    "optionSkills": {
+      "optionPicks": 1,
+      "anthropology": 30,
+      "typed:Art:rIgBrvKM": 30,
+      "typed:Craft:7wEbjUyG": 30,
+      "typed:Science:yw1JqTt0": 30
+    },
+    "optionSkillMeta": {
+      "typed:Art:rIgBrvKM": {
+        "chooseOne": true
+      },
+      "typed:Craft:7wEbjUyG": {
+        "chooseOne": true
+      },
+      "typed:Science:yw1JqTt0": {
+        "chooseOne": true
+      }
+    }
+  },
+  "effects": [],
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "deltagreen",
+    "systemVersion": "2.0.0-beta3",
+    "createdTime": 1782382835936,
+    "modifiedTime": 1782382835942,
+    "lastModifiedBy": "961R6wJiqwnS0zD3",
+    "exportSource": null,
+    "compendiumSource": null,
+    "duplicateSource": null
+  },
+  "ownership": {
+    "default": 0,
+    "961R6wJiqwnS0zD3": 3
+  },
+  "sort": 0,
+  "_key": "!items!cjlhFhpvqMswe8lS"
+}

--- a/packs/source/professions/Scientist_lp0CQ0AJm89yX5x6.json
+++ b/packs/source/professions/Scientist_lp0CQ0AJm89yX5x6.json
@@ -1,0 +1,65 @@
+{
+  "folder": null,
+  "name": "Scientist",
+  "type": "profession",
+  "_id": "lp0CQ0AJm89yX5x6",
+  "img": "systems/deltagreen/assets/icons/person-black-bg.svg",
+  "system": {
+    "description": "<p>See Page 22 of the Agent's Handbook.</p>",
+    "bonds": 4,
+    "automaticSkills": {
+      "bureaucracy": 40,
+      "computer_science": 40,
+      "typed:Science:fATJ22WJ": 60,
+      "typed:Science:culOBNJ7": 50,
+      "typed:Science:dk1d5RID": 50
+    },
+    "automaticSkillMeta": {
+      "typed:Science:fATJ22WJ": {
+        "chooseOne": true
+      },
+      "typed:Science:culOBNJ7": {
+        "chooseOne": true
+      },
+      "typed:Science:dk1d5RID": {
+        "chooseOne": true
+      }
+    },
+    "optionSkills": {
+      "optionPicks": 3,
+      "accounting": 50,
+      "typed:Craft:cU4nVvID": 40,
+      "typed:ForeignLanguage:ZllSp65K": 40,
+      "forensics": 40,
+      "law": 40,
+      "pharmacy": 40
+    },
+    "optionSkillMeta": {
+      "typed:Craft:cU4nVvID": {
+        "chooseOne": true
+      },
+      "typed:ForeignLanguage:ZllSp65K": {
+        "chooseOne": true
+      }
+    }
+  },
+  "effects": [],
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "deltagreen",
+    "systemVersion": "2.0.0-beta3",
+    "createdTime": 1782382835937,
+    "modifiedTime": 1782382835943,
+    "lastModifiedBy": "961R6wJiqwnS0zD3",
+    "exportSource": null,
+    "compendiumSource": null,
+    "duplicateSource": null
+  },
+  "ownership": {
+    "default": 0,
+    "961R6wJiqwnS0zD3": 3
+  },
+  "sort": 0,
+  "_key": "!items!lp0CQ0AJm89yX5x6"
+}

--- a/packs/source/professions/Soldier_or_Marine_vIyvnGYXLOhHDfgN.json
+++ b/packs/source/professions/Soldier_or_Marine_vIyvnGYXLOhHDfgN.json
@@ -1,0 +1,64 @@
+{
+  "folder": null,
+  "name": "Soldier or Marine",
+  "type": "profession",
+  "_id": "vIyvnGYXLOhHDfgN",
+  "img": "systems/deltagreen/assets/icons/person-black-bg.svg",
+  "system": {
+    "description": "<p>See Page 26 of the Agent's Handbook.</p>",
+    "bonds": 4,
+    "automaticSkills": {
+      "alertness": 50,
+      "athletics": 50,
+      "bureaucracy": 30,
+      "drive": 40,
+      "firearms": 40,
+      "first_aid": 40,
+      "Military Science (Land)": 40,
+      "navigate": 40,
+      "persuade": 30,
+      "unarmed_combat": 50
+    },
+    "automaticSkillMeta": {},
+    "optionSkills": {
+      "optionPicks": 3,
+      "artillery": 40,
+      "computer_science": 40,
+      "typed:Craft:PdQrtKaS": 40,
+      "demolitions": 40,
+      "typed:ForeignLanguage:SwGh6wLp": 40,
+      "heavy_machiner": 50,
+      "heavy_weapons": 40,
+      "search": 60,
+      "sigint": 40,
+      "swim": 60
+    },
+    "optionSkillMeta": {
+      "typed:Craft:PdQrtKaS": {
+        "chooseOne": true
+      },
+      "typed:ForeignLanguage:SwGh6wLp": {
+        "chooseOne": true
+      }
+    }
+  },
+  "effects": [],
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "deltagreen",
+    "systemVersion": "2.0.0-beta3",
+    "createdTime": 1782382835938,
+    "modifiedTime": 1782382835943,
+    "lastModifiedBy": "961R6wJiqwnS0zD3",
+    "exportSource": null,
+    "compendiumSource": null,
+    "duplicateSource": null
+  },
+  "ownership": {
+    "default": 0,
+    "961R6wJiqwnS0zD3": 3
+  },
+  "sort": 0,
+  "_key": "!items!vIyvnGYXLOhHDfgN"
+}

--- a/packs/source/professions/Special_Operator_ZIx4nl7VX79cTydU.json
+++ b/packs/source/professions/Special_Operator_ZIx4nl7VX79cTydU.json
@@ -1,0 +1,49 @@
+{
+  "folder": null,
+  "name": "Special Operator",
+  "type": "profession",
+  "_id": "ZIx4nl7VX79cTydU",
+  "img": "systems/deltagreen/assets/icons/person-black-bg.svg",
+  "system": {
+    "description": "<p>See Page 22 of the Agent's Handbook.</p>",
+    "bonds": 2,
+    "automaticSkills": {
+      "alertness": 60,
+      "athletics": 60,
+      "demolitions": 40,
+      "firearms": 60,
+      "heavy_weapons": 50,
+      "melee_weapons": 50,
+      "Military Science (Land)": 60,
+      "navigate": 50,
+      "stealth": 50,
+      "survival": 50,
+      "swim": 50,
+      "unarmed_combat": 60
+    },
+    "automaticSkillMeta": {},
+    "optionSkills": {
+      "optionPicks": 0
+    },
+    "optionSkillMeta": {}
+  },
+  "effects": [],
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "deltagreen",
+    "systemVersion": "2.0.0-beta3",
+    "createdTime": 1782382835938,
+    "modifiedTime": 1782382835944,
+    "lastModifiedBy": "961R6wJiqwnS0zD3",
+    "exportSource": null,
+    "compendiumSource": null,
+    "duplicateSource": null
+  },
+  "ownership": {
+    "default": 0,
+    "961R6wJiqwnS0zD3": 3
+  },
+  "sort": 0,
+  "_key": "!items!ZIx4nl7VX79cTydU"
+}

--- a/system.json
+++ b/system.json
@@ -110,6 +110,7 @@
         "firearms",
         "armor",
         "hand-to-hand-weapons",
+        "professions",
         "agent-pregens",
         "operation-code-name-generator-tables"
       ],
@@ -153,6 +154,18 @@
       "label": "Hand-to-Hand Weapons",
       "system": "deltagreen",
       "path": "packs/hand-to-hand-weapons",
+      "type": "Item",
+      "flags": {},
+      "ownership": {
+        "PLAYER": "OBSERVER",
+        "ASSISTANT": "OWNER"
+      }
+    },
+    {
+      "name": "professions",
+      "label": "Professions",
+      "system": "deltagreen",
+      "path": "packs/professions",
       "type": "Item",
       "flags": {},
       "ownership": {


### PR DESCRIPTION
## Checklist

<!-- Check one or more: -->

- [x] This is meant for the next release.
- [ ] This is meant for a hotfix.
- [ ] This is a Build System change.
- [ ] This needs more reviewers than normal
- [ ] This intentionally introduces regressions that will be addressed later.
- [ ] The change will require updates to the documentation.
- [ ] Please do not send commits here without coordinating closely with the owner.

## What does this PR do?

This gets the compendia for the core professions within the Agents Handbook available in the system, and which also makes it
possible to easily use the character creator.

The work of building out the compendium content was done by @Vogliadicone (huge props!).

<!-- Briefly describe the purpose of the PR and what it changes. -->

## How to Test

1. Follow compendium installation instructions within CONTRIBUTORS.md
2. Open world running Delta Green
3. In the compendium, expand Delta Green then click on Professions
4. Drag a profession onto a character sheet to initiate the character creation process

<img width="427" height="1168" alt="image" src="https://github.com/user-attachments/assets/1bdb6cd1-38da-4e6b-8ffb-e725bc63022d" />


## Related Issue(s)

<!-- Link to issues this PR closes/fixes. Use GitHub auto-closing keywords if appropriate. -->

Closes #436

## Future Work

<!-- Describe any follow-up work, improvements, or additional features related to this PR. -->
