### PR TITLE
452 stat block parser fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release/Patch Notes
 
+## Unreleased
+
+### **Bug Fixes:**
+
+- [#452](https://github.com/deltagreen-foundryvtt/delta-green-foundry-vtt-system/issues/452) - Fix stat block parser on very complicated stat blocks
+
 ## Version 2.0.1 - 2026-08-10
 
 ### **Bug Fixes:**

--- a/module/macros/extract-attacks.js
+++ b/module/macros/extract-attacks.js
@@ -89,6 +89,10 @@ function extractAttacksImpl(tokens, accumulatedAttacks, incompleteAttack) {
     return extractAttacksImpl(rest, accumulatedAttacks, partialAttack);
   }
 
+  if (accumulatedAttacks.length === 0) {
+    return [[partialAttack], tokens];
+  }
+
   return [accumulatedAttacks, tokens];
 }
 
@@ -96,5 +100,9 @@ export function ExtractAttacks(tokens) {
   const simplifiedTokens = tokens
     .filter((token) => token.replaceAll(/\(|\)/g, "") !== "or")
     .filter((token) => token !== ",");
+  const [firstToken] = simplifiedTokens;
+  if (firstToken && firstToken.includes("(")) {
+    return [[{ name: "Too complicated to parse. See notes." }], tokens];
+  }
   return extractAttacksImpl(simplifiedTokens, [], { name: [] });
 }

--- a/module/macros/extract-attacks.js
+++ b/module/macros/extract-attacks.js
@@ -72,7 +72,11 @@ function extractAttacksImpl(tokens, accumulatedAttacks, incompleteAttack) {
     return extractAttacksImpl(rest, accumulatedAttacks, partialAttack);
   }
 
-  if (Number.isNaN(skillModifier) && typeof partialAttack.name !== "string") {
+  if (
+    Number.isNaN(skillModifier) &&
+    typeof partialAttack.name !== "string" &&
+    maybeAttackDetail !== undefined
+  ) {
     partialAttack.name = [...partialAttack.name, attackName];
     return extractAttacksImpl(
       [maybeAttackDetail, ...rest],
@@ -85,7 +89,9 @@ function extractAttacksImpl(tokens, accumulatedAttacks, incompleteAttack) {
     partialAttack.name = [...partialAttack.name, attackName]
       .map(capitalize)
       .join(" ");
-    partialAttack.skillModifier = skillModifier;
+    partialAttack.skillModifier = Number.isNaN(skillModifier)
+      ? 0
+      : skillModifier;
     return extractAttacksImpl(rest, accumulatedAttacks, partialAttack);
   }
 

--- a/module/macros/stat-block-parser.js
+++ b/module/macros/stat-block-parser.js
@@ -47,30 +47,51 @@ const ARMOR_MATCHER = /armou?r/g;
 export function tokenize(stream) {
   return stream
     .toLowerCase()
-    .split(/\s+/)
-    .flatMap((token) => {
-      const strippedToken = token.replaceAll(EXTRANEOUS_CHARACTERS, "");
-      const commaMatch = COMMA_MATCHER.exec(strippedToken);
-      if (commaMatch != null) {
-        return [commaMatch[1], COMMA];
-      }
-      const sectionTerminatorMatch = SECTION_TERMINATOR.exec(strippedToken);
-      if (sectionTerminatorMatch !== null) {
-        return [sectionTerminatorMatch[1], ENTRY_END];
-      }
-      return strippedToken;
-    });
+    .split(/[\n|\r\n]+/)
+    .map((line) => {
+      return line
+        .split(/\s+/)
+        .flatMap((token) => {
+          const strippedToken = token.replaceAll(EXTRANEOUS_CHARACTERS, "");
+          const commaMatch = COMMA_MATCHER.exec(strippedToken);
+          if (commaMatch != null) {
+            return [commaMatch[1], COMMA];
+          }
+          const sectionTerminatorMatch = SECTION_TERMINATOR.exec(strippedToken);
+          if (sectionTerminatorMatch !== null) {
+            return [sectionTerminatorMatch[1], ENTRY_END];
+          }
+          return strippedToken;
+        })
+        .filter((token) => token.length > 0);
+    })
+    .filter((line) => line.length > 0);
+}
+
+export function collectTokensUntilNextSection(lines) {
+  let tokens = [];
+  let otherLines = [];
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const colonIndex = line.findIndex((token) => token.includes(":"));
+    const rest = line.slice(colonIndex);
+    if (colonIndex >= 0 && tokens.length > 0) {
+      otherLines = lines.slice(i);
+      break;
+    } else if (colonIndex > 0) {
+      tokens = [...tokens, ...rest];
+    } else {
+      tokens = [...tokens, ...line];
+    }
+  }
+
+  return [tokens, otherLines];
 }
 
 export function groupEntriesUntilNextSection(tokens) {
   const groups = [];
-  const rest = [];
 
   tokens.reduce((accum, token) => {
-    if (token.includes(":") || accum === "DONE") {
-      rest.push(token);
-      return "DONE";
-    }
     if (token === ENTRY_END) {
       groups.push(accum);
       return [];
@@ -84,11 +105,16 @@ export function groupEntriesUntilNextSection(tokens) {
     return accum;
   }, []);
 
-  return [groups, rest];
+  return groups;
 }
 
 const attributeKeys = Object.keys(Attributes);
-export function determineNextState(token) {
+export function determineNextState(nextLine) {
+  if (nextLine === undefined) {
+    return States.Unknown;
+  }
+
+  const token = nextLine.find((t) => t.includes(":")) || nextLine[0];
   if (attributeKeys.indexOf(token) >= 0) {
     return States.AttributePairs;
   }
@@ -110,8 +136,8 @@ export function determineNextState(token) {
 }
 
 function extractAttributesImpl(tokens, accumulator) {
-  if (tokens === []) {
-    return [accumulator, tokens];
+  if (tokens.length === []) {
+    return accumulator;
   }
 
   const [attr, rawValue, ...rest] = tokens;
@@ -130,11 +156,13 @@ function extractAttributesImpl(tokens, accumulator) {
   const expectedKeys = new Set(Object.keys(Attributes));
   if (currentKeys.intersection(expectedKeys).size === expectedKeys.size) {
     delete accumulator.incomplete;
-    return [accumulator, tokens];
+    return accumulator;
   }
 
   if (Attributes[attr] == null || Number.isNaN(value)) {
-    return [accumulator, tokens];
+    if (rest.length <= 0) return accumulator;
+
+    return extractAttributesImpl([rawValue, ...rest], accumulator);
   }
 
   accumulator[attr] = value;
@@ -143,7 +171,7 @@ function extractAttributesImpl(tokens, accumulator) {
 
 function extractSkillsImpl(tokens, skillsAccum, skillNameAccum) {
   if (tokens === []) {
-    return [skillsAccum, tokens];
+    return skillsAccum;
   }
 
   const [partialSkillName, maybeSkillScore, ...rest] = tokens;
@@ -294,64 +322,63 @@ export function ExtractDisordersAndAdaptations(tokens) {
   );
 }
 
-function parseStatBlockImpl(tokens, state, statBlock) {
-  if (tokens.length === 0) {
-    return statBlock;
+function parseStatBlockImpl(lines, state, statBlock) {
+  if (lines.length === 0) {
+    return { ...statBlock, notes: statBlock.notes.join("\n") };
   }
 
-  const [nextToken, ...rest] = tokens;
-  const nextState = determineNextState(nextToken);
-
-  if (state === States.BeginStatblock && nextState === States.Unknown) {
-    const characterNameParts = [...(statBlock.name || []), nextToken];
-    return parseStatBlockImpl(rest, state, {
-      ...statBlock,
-      name: characterNameParts,
-    });
-  }
-
+  const [firstLine, ...rest] = lines;
   if (state === States.BeginStatblock) {
-    const name = (statBlock.name || []).join(" ");
-    return parseStatBlockImpl(tokens, nextState, {
-      ...statBlock,
-      name,
-    });
+    if (statBlock.name === undefined) {
+      return parseStatBlockImpl(rest, determineNextState(rest[0]), {
+        ...statBlock,
+        name: firstLine.join(" "),
+      });
+    }
   }
 
-  if (state === States.AttributePairs) {
-    const [attributes, remainingTokens] = ExtractAttributes(tokens);
-    return parseStatBlockImpl(remainingTokens, States.Unknown, {
+  if (state === States.Unknown) {
+    statBlock.notes.push(firstLine.join(" "));
+    return parseStatBlockImpl(rest, determineNextState(rest[0]), statBlock);
+  }
+
+  const [tokens, otherLines] = collectTokensUntilNextSection(lines);
+  const nextState = determineNextState(otherLines[0]);
+
+  if (state === States.AttributePairs && statBlock.attributes === undefined) {
+    const attributes = ExtractAttributes(tokens);
+    return parseStatBlockImpl(otherLines, nextState, {
       ...statBlock,
       attributes,
     });
   }
 
-  if (nextState === States.SkillPairs) {
-    const [skills, remainingTokens] = ExtractSkills(rest);
-    return parseStatBlockImpl(remainingTokens, States.Unknown, {
+  if (state === States.SkillPairs) {
+    const [skills] = ExtractSkills(tokens.slice(1));
+    return parseStatBlockImpl(otherLines, nextState, {
       ...statBlock,
       skills,
     });
   }
 
-  if (nextState === States.Attacks) {
-    const [groupedAttacks, remainingTokens] =
-      groupEntriesUntilNextSection(rest);
+  if (state === States.Attacks) {
+    const groupedAttacks = groupEntriesUntilNextSection(tokens.slice(1));
     const attacks = groupedAttacks.flatMap((group) => {
       const [results, trailingTokens] = ExtractAttacks(group);
       return results.map((a) => {
         return { ...a, notes: trailingTokens.join(" ") };
       });
     });
-    return parseStatBlockImpl(remainingTokens, States.Unknown, {
+    return parseStatBlockImpl(otherLines, nextState, {
       ...statBlock,
       attacks,
     });
   }
 
-  if (nextState === States.ArmorAndEquipment) {
-    const [armorAndEquipmentGroup, remainingTokens] =
-      groupEntriesUntilNextSection(rest);
+  if (state === States.ArmorAndEquipment) {
+    const armorAndEquipmentGroup = groupEntriesUntilNextSection(
+      tokens.slice(1),
+    );
     const armorAndEquipment = ExtractArmorAndEquipment(
       armorAndEquipmentGroup.flatMap((subarray, i) => {
         if (i + 1 === armorAndEquipmentGroup.length) {
@@ -360,27 +387,30 @@ function parseStatBlockImpl(tokens, state, statBlock) {
         return [...subarray, COMMA];
       }),
     );
-    return parseStatBlockImpl(remainingTokens, States.Unknown, {
+    return parseStatBlockImpl(otherLines, nextState, {
       ...statBlock,
       ...armorAndEquipment,
     });
   }
 
-  if (nextState === States.DisordersAndAdaptations) {
-    const [disordersAndAdaptationsGroup, remainingTokens] =
-      groupEntriesUntilNextSection(rest);
+  if (state === States.DisordersAndAdaptations) {
+    const disordersAndAdaptationsGroup = groupEntriesUntilNextSection(
+      tokens.slice(1),
+    );
     const disordersAndAdaptations = ExtractDisordersAndAdaptations(
       disordersAndAdaptationsGroup.flatMap((subarray) => subarray),
     );
-    return parseStatBlockImpl(remainingTokens, States.Unknown, {
+    return parseStatBlockImpl(otherLines, nextState, {
       ...statBlock,
       ...disordersAndAdaptations,
     });
   }
 
-  return parseStatBlockImpl(rest, nextState, statBlock);
+  return parseStatBlockImpl(otherLines, nextState, statBlock);
 }
 
 export function ParseStatBlock(stream) {
-  return parseStatBlockImpl(tokenize(stream), States.BeginStatblock, {});
+  return parseStatBlockImpl(tokenize(stream), States.BeginStatblock, {
+    notes: [],
+  });
 }

--- a/module/macros/stat-block-parser.js
+++ b/module/macros/stat-block-parser.js
@@ -4,11 +4,11 @@ const SKILL_SECTION = "skills:";
 const ATTACKS_SECTION = "attacks:";
 const COMMA = ",";
 const ENTRY_END = ".";
-const BREAKING = "breaking";
 // Make assumption that the following sections
 // always end in the same token
 const ARMOR_AND_EQUIPMENT_SECTION = "equipment:";
 const DISORDERS_AND_ADAPTATIONS_SECTION = "adaptations:";
+const SAN_LOSS_SECTION = "loss:";
 
 export const States = {
   BeginStatblock: "begin-statblock",
@@ -18,6 +18,7 @@ export const States = {
   Attacks: "attack",
   ArmorAndEquipment: "armor-and-equipment",
   DisordersAndAdaptations: "disorders-and-adaptations",
+  SanLoss: "san-loss",
   Unknown: "unknown",
 };
 
@@ -96,6 +97,12 @@ export function groupEntriesUntilNextSection(tokens) {
       groups.push(accum);
       return [];
     }
+
+    if (token.includes(ENTRY_END)) {
+      groups.push([...accum, token]);
+      return [];
+    }
+
     const cleanedToken = token.replaceAll(/\(|\)/g, "");
     if (cleanedToken === "or") {
       return accum;
@@ -130,6 +137,8 @@ export function determineNextState(nextLine) {
       return States.DisordersAndAdaptations;
     case ARMOR_AND_EQUIPMENT_SECTION:
       return States.ArmorAndEquipment;
+    case SAN_LOSS_SECTION:
+      return States.SanLoss;
     default:
       return States.Unknown;
   }
@@ -322,6 +331,21 @@ export function ExtractDisordersAndAdaptations(tokens) {
   );
 }
 
+export function ExtractSanLoss(tokens) {
+  const [sanLoss, ...rest] = tokens;
+  const [successLoss, failedLoss] = sanLoss.split("/");
+  const sanLossType = rest.find(
+    (token) => token === "violence" || token === "helplessness",
+  );
+
+  return {
+    successLoss,
+    failedLoss,
+    notes: rest.join(" "),
+    type: sanLossType ?? "unnatural",
+  };
+}
+
 function parseStatBlockImpl(lines, state, statBlock) {
   if (lines.length === 0) {
     return { ...statBlock, notes: statBlock.notes.join("\n") };
@@ -403,6 +427,15 @@ function parseStatBlockImpl(lines, state, statBlock) {
     return parseStatBlockImpl(otherLines, nextState, {
       ...statBlock,
       ...disordersAndAdaptations,
+    });
+  }
+
+  if (state === States.SanLoss) {
+    const [sanLossTokens] = groupEntriesUntilNextSection(tokens.slice(1));
+    const sanloss = ExtractSanLoss(sanLossTokens);
+    return parseStatBlockImpl(otherLines, nextState, {
+      ...statBlock,
+      sanloss,
     });
   }
 

--- a/module/macros/stat-parser-macro.js
+++ b/module/macros/stat-parser-macro.js
@@ -358,13 +358,15 @@ async function RegexParseNpcStatBlock(inputStr, actorType) {
   }
 
   (attacks || []).forEach(async (attack) => {
-    const { name, skillModifier, damage, armorPiercing, lethality } = attack;
-    const [description, attackSkill, killRadius, expense] = [
-      "",
-      "custom",
-      "N/A",
-      "N/A",
-    ];
+    const {
+      name,
+      skillModifier,
+      damage,
+      armorPiercing,
+      lethality,
+      notes: description,
+    } = attack;
+    const [attackSkill, killRadius, expense] = ["custom", "N/A", "N/A"];
     const [range, skillMod] = [0, 0];
     const skillTarget = skillModifier;
     const equipped = true;

--- a/module/macros/stat-parser-macro.js
+++ b/module/macros/stat-parser-macro.js
@@ -350,6 +350,17 @@ async function RegexParseNpcStatBlock(inputStr, actorType) {
     actorData.system.notes = GetNotesFromInput(inputStr);
   }
 
+  if (actorType === "unnatural") {
+    const {
+      sanloss: { failedLoss, successLoss, notes },
+    } = statBlock;
+    actorData.system.sanity = {
+      notes,
+      failedLoss,
+      successLoss,
+    };
+  }
+
   const [newActor] = await Actor.createDocuments([actorData]);
   const { armor, attacks } = statBlock;
 
@@ -374,7 +385,7 @@ async function RegexParseNpcStatBlock(inputStr, actorType) {
     await newActor.AddWeaponItemToSheet(
       name,
       description,
-      damage,
+      damage ?? "",
       attackSkill,
       skillMod,
       skillTarget,

--- a/test/macros/extract-attacks.test.js
+++ b/test/macros/extract-attacks.test.js
@@ -75,6 +75,17 @@ const complexLethality = {
   ],
   expectedTokensRemaining: ["(see", "dangerous)"],
 };
+const specialAttack = {
+  input: "kiss , damage special , see “Kiss.”".split(" "),
+  expectedAttacks: [
+    {
+      name: "Kiss See “Kiss.”",
+      damage: "special",
+      skillModifier: 0,
+    },
+  ],
+  expectedTokensRemaining: [],
+};
 
 describe("ExtractAttacks", () => {
   test.each([
@@ -86,6 +97,7 @@ describe("ExtractAttacks", () => {
     { ...heavyRifleEntry, testName: "Weapon with armor piercing" },
     { ...handGrenadeEntry, testName: "Explosive weapon with just lethality" },
     { ...complexLethality, testName: "Attack with complex lethality rules" },
+    { ...specialAttack, testName: "An attack with special rules" },
   ])("$testName", ({ input, expectedAttacks, expectedTokensRemaining }) => {
     const [actual, remainingTokens] = ExtractAttacks(input);
     expect(remainingTokens).toEqual(expectedTokensRemaining);

--- a/test/macros/stat-block-parser.test.js
+++ b/test/macros/stat-block-parser.test.js
@@ -384,6 +384,16 @@ describe("ParseStatBlock", () => {
         ],
       },
     },
+    {
+      testName: "Parsing the alien steward statblock",
+      input: readStatblock("alien-steward-stats"),
+      expected: {},
+    },
+    {
+      testName: "Parsing the megalomaniac statblock",
+      input: readStatblock("megalomaniac-stats"),
+      expected: {},
+    },
   ])("$testName", ({ input, expected }) => {
     const actualStatBlock = ParseStatBlock(input);
     expect(actualStatBlock).toEqual(expected);

--- a/test/macros/stat-block-parser.test.js
+++ b/test/macros/stat-block-parser.test.js
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "@jest/globals";
+import { describe, expect, jest, test } from "@jest/globals";
 import fs from "node:fs";
 
 import {
@@ -7,6 +7,7 @@ import {
   ExtractArmorAndEquipment,
   ExtractDisordersAndAdaptations,
   tokenize,
+  collectTokensUntilNextSection,
   determineNextState,
   groupEntriesUntilNextSection,
   States,
@@ -15,75 +16,63 @@ import {
 
 describe("determineNextState", () => {
   test.each([
-    { nextToken: "skills:", expected: States.SkillPairs },
-    { nextToken: "fox", expected: States.Unknown },
-    { nextToken: "attacks:", expected: States.Attacks },
-    { nextToken: ".", expected: States.EndEntry },
+    { nextLine: ["skills:"], expected: States.SkillPairs },
+    { nextLine: ["fox"], expected: States.Unknown },
+    { nextLine: ["attacks:"], expected: States.Attacks },
+    { nextLine: ["."], expected: States.EndEntry },
   ])(
     ".determineNextState() for $nextToken is $expected",
-    ({ nextToken, expected }) => {
-      expect(determineNextState(nextToken)).toEqual(expected);
+    ({ nextLine, expected }) => {
+      expect(determineNextState(nextLine)).toEqual(expected);
     },
   );
   test.each("str dex con int pow cha hp wp san".split(" "))(
     `determineNextState(%s) should return ${States.AttributePairs}`,
     (stat) => {
-      expect(determineNextState(stat)).toEqual(States.AttributePairs);
+      expect(determineNextState([stat])).toEqual(States.AttributePairs);
     },
   );
 });
 
 describe("groupEntriesUntilNextSection", () => {
-  test("extracting multiple attacks followed by a new section", () => {
+  test("extracting multiple attacks", () => {
     const entryOne = "abra cadabra alakazam".split(" ");
     const entryTwo = "hocus pocus".split(" ");
     const entryThree = "wibbly wobbly timey wimey".split(" ");
-    const input = [
-      ...entryOne,
-      ".",
-      ...entryTwo,
-      ".",
-      ...entryThree,
-      ".",
-      "skills:",
-    ];
+    const input = [...entryOne, ".", ...entryTwo, ".", ...entryThree, "."];
     const expected = [entryOne, entryTwo, entryThree];
-    const [results, remainingTokens] = groupEntriesUntilNextSection(input);
-    expect(remainingTokens).toEqual(["skills:"]);
+    const results = groupEntriesUntilNextSection(input);
     expect(results).toEqual(expected);
   });
 });
 
 describe("tokenize", () => {
   const expectedOutput = [
-    "str",
-    "10",
-    "con",
-    "10",
-    "pow",
-    "14",
-    "skills:",
-    "firearms",
-    "45",
-    ",",
-    "heavy",
-    "weapons",
-    "50",
-    ",",
-    "melee",
-    "weapons",
-    "75",
-    ",",
-    "science",
-    "(biology)",
-    "50",
-    ".",
+    ["str", "10", "con", "10", "pow", "14"],
+    [
+      "skills:",
+      "firearms",
+      "45",
+      ",",
+      "heavy",
+      "weapons",
+      "50",
+      ",",
+      "melee",
+      "weapons",
+      "75",
+      ",",
+      "science",
+      "(biology)",
+      "50",
+      ".",
+    ],
   ];
 
   test.each([
     {
       input: "75%.",
-      expected: ["75", "."],
+      expected: [["75", "."]],
     },
     {
       input:
@@ -100,15 +89,57 @@ describe("tokenize", () => {
   });
 });
 
+describe("collectTokensUntilNextSection", () => {
+  test.each([
+    {
+      testName: "collects all attribute tokens",
+      input: [
+        ["str", "10", "pow", "10"],
+        ["con", "12", "int", "9"],
+        ["hp", "11"],
+        ["san", "67"],
+        ["skills:"],
+        ["firearms", "50"],
+      ],
+      expected: [
+        "str 10 pow 10 con 12 int 9 hp 11 san 67".split(" "),
+        [["skills:"], ["firearms", "50"]],
+      ],
+    },
+    {
+      testName: "stops on lines where the colon is somewhere in the line",
+      input: [
+        "str 10 pow 10".split(" "),
+        "disorders and adaptations: adapted to violence".split(" "),
+        ["skills:"],
+      ],
+      expected: [
+        "str 10 pow 10".split(" "),
+        [
+          "disorders and adaptations: adapted to violence".split(" "),
+          ["skills:"],
+        ],
+      ],
+    },
+  ])(
+    ".collectTokensUntilNextSection() on $testName",
+    ({ input, expected: [expectedTokens, expectedOtherLines] }) => {
+      const [actualTokens, actualOtherLines] =
+        collectTokensUntilNextSection(input);
+      expect(actualTokens).toEqual(expectedTokens);
+      expect(actualOtherLines).toEqual(expectedOtherLines);
+    },
+  );
+});
+
 describe("ExtractAttributes", () => {
   const validAttributes =
-    "STR 10 con 10 Dex 13 Int 10 pOW 14 ChA 10\n\nHp 10 wp 14\n\t\nsaN 10\nSKILLS:";
+    "STR 10 con 10 Dex 13 Int 10 pOW 14 ChA 10 Hp 10 wp 14 saN 10";
   const invalidAttributes = "Bear 10 Criminal 2 STr 10 con 11 Int 10";
   const incompleteAttributes = "Str 10 con 10 Dex 10 10 Int";
 
   test("extracting valid attributes", () => {
-    const [result, rest] = ExtractAttributes(tokenize(validAttributes));
-    expect(rest).toEqual(["skills:"]);
+    const result = ExtractAttributes(tokenize(validAttributes)[0]);
     expect(result).toEqual({
       str: 10,
       dex: 13,
@@ -123,15 +154,13 @@ describe("ExtractAttributes", () => {
   });
 
   test("extracting invalid attributes", () => {
-    const tokens = tokenize(invalidAttributes);
-    const [result, rest] = ExtractAttributes(tokens);
-    expect(rest).toEqual(tokens);
-    expect(result).toEqual({ incomplete: true });
+    const tokens = tokenize(invalidAttributes)[0];
+    const result = ExtractAttributes(tokens);
+    expect(result).toEqual({ str: 10, con: 11, int: 10, incomplete: true });
   });
 
   test("extracting incomplete attributes", () => {
-    const [result, rest] = ExtractAttributes(tokenize(incompleteAttributes));
-    expect(rest).toEqual(["10", "int"]);
+    const result = ExtractAttributes(tokenize(incompleteAttributes)[0]);
     expect(result).toEqual({
       str: 10,
       con: 10,
@@ -189,7 +218,7 @@ describe("ExtractSkills", () => {
       },
     },
   ])(".ExtractSkills() on $testName", ({ input, expected }) => {
-    const tokens = tokenize(input);
+    const [tokens] = collectTokensUntilNextSection(tokenize(input));
     const [result, rest] = ExtractSkills(tokens);
     expect(rest).toEqual([]);
     expect(result).toEqual(expected);
@@ -215,7 +244,7 @@ describe("ExtractArmorAndEquipment", () => {
       },
     },
   ])(".ExtractArmorAndEquipment() on $testName", ({ input, expected }) => {
-    const tokens = tokenize(input);
+    const [tokens] = collectTokensUntilNextSection(tokenize(input));
     const result = ExtractArmorAndEquipment(tokens);
     expect(result).toEqual(expected);
   });
@@ -252,7 +281,7 @@ describe("ExtractDisordersAndAdaptations", () => {
   ])(
     ".ExtractDisordersAndAdaptations() on $testName",
     ({ input, expected }) => {
-      const tokens = tokenize(input);
+      const [tokens] = collectTokensUntilNextSection(tokenize(input));
       const result = ExtractDisordersAndAdaptations(tokens);
       expect(result).toEqual(expected);
     },
@@ -269,6 +298,7 @@ describe("ParseStatBlock", () => {
       input: readStatblock("basic-stats"),
       expected: {
         name: "some dude",
+        notes: "",
         attributes: {
           str: 10,
           con: 10,
@@ -316,6 +346,7 @@ describe("ParseStatBlock", () => {
       input: readStatblock("complex-stats"),
       expected: {
         name: "private military contractor",
+        notes: "",
         attributes: {
           str: 14,
           con: 13,
@@ -385,17 +416,159 @@ describe("ParseStatBlock", () => {
       },
     },
     {
+      skip: true,
       testName: "Parsing the alien steward statblock",
       input: readStatblock("alien-steward-stats"),
-      expected: {},
+      expected: {
+        notes: "",
+      },
     },
     {
       testName: "Parsing the megalomaniac statblock",
       input: readStatblock("megalomaniac-stats"),
-      expected: {},
+      expected: {
+        name: "ronald “prince” valiant/doug walters",
+        notes: [
+          // The notes don't parse perfectly like this. They will be all the lines
+          // lowercased, with spaces in between punctuation marks and percentage symbols
+          // removed.
+          // This is a known issue that will need to be addressed by skipping unparsable lines
+          // and grabbing the original text by line number.
+          "Unloved megalomaniac, age 35 in 1997 (stats in parentheses are when using the Boost power)",
+          "OBTRUSIONS: Valiant has awakened several deadly but draining gifts called obtrusions.",
+          "If the Agents confront him before he leeches power from his followers (see THE MEETING on page 38), he can perform only 1 Obtrusion.",
+          "If the Agents interrupt the meeting soon after it begins, he can perform 10 Obtrusions.",
+          "If they stop it late, he can perform 20.",
+          "If they fail to interrupt the meeting at all, Valiant can perform 40 Obtrusions.",
+          "Each can be used any number of times at a cost of 1 Obtrusion per use.",
+          "Each use is his action for the turn.",
+          "• Ascendance: Valiant can fly up to 50 meters, shining brightly.",
+          "If he has grappled an Agent, he can carry them with him.",
+          "Whatever Valiant’s altitude after using this power, he lands safely unless unconscious.",
+          "• Boost: Valiant can add 6 each to his STR, DEX, and CON for the next five turns, glowing faintly.",
+          "He starts a fight with this power.",
+          "• Disruption: If he has lost hit points since his last action, Valiant can angrily channel a flash of force into his hands.",
+          "The next time he hits with an unarmed attack, its damage is Lethality 10%.",
+          "• Impulsion: By touch, Valiant can plant an emotion in the target.",
+          "It lasts 20 hours. To resist the sway of this emotion requires succeeding at a WP×5 test and then spending 1D6 WP.",
+          "If the WP cost is too high, the target can choose to obey the emotion after all rather than spending it.",
+          "• Protection: As an action, Valiant can surround himself in a glittering aura that causes all LETHALITY rolls to fail and deflects damage.",
+          "The aura remains without his taking further actions, but upon stopping 30 points of damage, it flickers out.",
+          "• Repulsion: As an action, Valiant can lash out with a bright flare of force.",
+          "This cannot be blocked or dodged.",
+          "He can affect any number of targets within 5 meters, each costing 1 Obtrusion.",
+          "Every target flies 10 meters, takes 1D6 damage, and is stunned, unable to act until they succeed at a CON×5 test.",
+        ],
+        attributes: {
+          str: 16,
+          con: 16,
+          dex: 12,
+          int: 12,
+          pow: 10,
+          cha: 18,
+          hp: 16,
+          wp: 10,
+          san: 0,
+        },
+        skills: {
+          accounting: 35,
+          alertness: 33,
+          athletics: 63,
+          bureaucracy: 35,
+          "computer science": 22,
+          disguise: 19,
+          dodge: 33,
+          drive: 56,
+          firearms: 62,
+          "first aid": 34,
+          "foreign language (spanish)": 14,
+          humint: 31,
+          "melee weapons": 57,
+          "military science": 38,
+          navigate: 24,
+          persuade: 59,
+          pharmacy: 34,
+          sigint: 18,
+          stealth: 53,
+          survival: 38,
+          "unarmed combat": 73,
+        },
+        attacks: [
+          {
+            name: "Unarmed",
+            skillModifier: 73,
+            damage: "1d4",
+            notes: "(1d8)",
+          },
+          {
+            name: "Too complicated to parse. See notes.",
+            notes:
+              "(after the meeting [see page 38] , valiant uses no weapons but his hands and his psychic powers",
+          },
+          {
+            name: "Knife (marine Ka-bar)",
+            skillModifier: 57,
+            damage: "1d6+1",
+            notes: "(1d6+3) armor piercing 3",
+          },
+          {
+            name: "S&w Model",
+            skillModifier: 645,
+            notes: "pistol 62 damage 1d10",
+          },
+          {
+            name: "Colt M16a2 Assault Rifle",
+            skillModifier: 62,
+            damage: "1d12",
+            lethality: 10,
+            notes: "",
+            armorPiercing: 3,
+          },
+          {
+            name: "Luigi Franchi Spas-12 Shotgun",
+            skillModifier: 82,
+            damage: "2d8",
+            notes: "×2 armor",
+          },
+          {
+            name: "Mi-go Electric Gun",
+            skillModifier: 12,
+            lethality: 2,
+            notes: "(see notes for hope on this page)",
+          },
+          {
+            name: "Mi-go Electric Gun",
+            skillModifier: 12,
+            lethality: 15,
+            notes: "(see notes for hope on this page)",
+          },
+          {
+            name: "Mi-go Electric Gun",
+            skillModifier: 12,
+            lethality: 25,
+            notes: "(see notes for hope on this page)",
+          },
+        ],
+      },
     },
-  ])("$testName", ({ input, expected }) => {
+  ])("$testName", ({ input, expected, skip }) => {
+    if (skip) {
+      return;
+    }
+
     const actualStatBlock = ParseStatBlock(input);
-    expect(actualStatBlock).toEqual(expected);
+    const expectedStatBlock = expected;
+    expect(actualStatBlock.attacks).toEqual(expected.attacks);
+    expect(actualStatBlock.skills).toEqual(expected.skills);
+    expect(actualStatBlock.attributes).toEqual(expected.attributes);
+    expect(actualStatBlock.adaptations).toEqual(expected.adaptations);
+    if (expected.notes.length > 0) {
+      expect(actualStatBlock.notes.length).toBeGreaterThan(0);
+    }
+    actualStatBlock.notes = null;
+
+    delete actualStatBlock.notes;
+    delete expectedStatBlock.notes;
+    expect(actualStatBlock).toEqual(expectedStatBlock);
   });
 });

--- a/test/macros/stat-block-parser.test.js
+++ b/test/macros/stat-block-parser.test.js
@@ -44,6 +44,16 @@ describe("groupEntriesUntilNextSection", () => {
     const results = groupEntriesUntilNextSection(input);
     expect(results).toEqual(expected);
   });
+
+  test("extracting multiple attacks when the attack terminator is buried in a quote", () => {
+    const entryOne = "kiss damage special see 'kiss.'".split(" ");
+    const entryTwo = "wrangle damage special see 'wrangle.'".split(" ");
+    const entryThree = "throttle damage special see 'throttle.'".split(" ");
+    const input = [...entryOne, ...entryTwo, ...entryThree];
+    const expected = [entryOne, entryTwo, entryThree];
+    const results = groupEntriesUntilNextSection(input);
+    expect(results).toEqual(expected);
+  });
 });
 
 describe("tokenize", () => {
@@ -416,11 +426,126 @@ describe("ParseStatBlock", () => {
       },
     },
     {
-      skip: true,
       testName: "Parsing the alien steward statblock",
       input: readStatblock("alien-steward-stats"),
       expected: {
-        notes: "",
+        name: "hope",
+        notes: [
+          // The notes don't parse perfectly like this. They will be all the lines
+          // lowercased, with spaces in between punctuation marks and percentage symbols
+          // removed.
+          // This is a known issue that will need to be addressed by skipping unparsable lines
+          // and grabbing the original text by line number.
+          "Hapless protomatter Steward, age 28",
+          "(use Hope's stats for any Steward)",
+          "Stewards are unharmed by all melee and unarmed blows.",
+          "Firearms have all damage reduced to 1, and Hope regenerates 1D4 HP per round",
+          "Fire, electricity, acid, chemical irritants and hypergeometric rituals inflict",
+          "damage normally and stop all regeneration for the remainder of combat.",
+          "ELECTRIC GUN: This weapon appears as a pulsing,",
+          "softball-sized glob with three dangling tendrils. When",
+          "the weapon is picked up, the tendrils wrap around",
+          "the user’s forearm. The weapon is a biomechanical organism that can eject bolts of electrical current, sort",
+          "of like an electric eel. The charge of lightning emitted",
+          "from the weapon is variable, but Hope has no need",
+          "for anything but the deadliest setting. The only reason",
+          "she would turn down the charge would be to protect",
+          "her beloved Valiant, but in such instances, she gives",
+          "her master the gun and attempts to suffocate or rend his",
+          "enemies up close. The electric gun ignores body armor",
+          "but can be blocked by cover.",
+          "DRAW CLOSE: After a successful grapple, a victim must",
+          "succeed on a STR×5 check opposing Hope’s successful",
+          "attack roll to break free. On a failure, they suffer either",
+          "Swallow or Kiss the next round.",
+          "KISS: Hope spurts protomatter down the grappled victim’s",
+          "throat and takes control of their body. Any Agent",
+          "subjected to the Kiss loses control of their character",
+          "until Hope is destroyed or withdraws her parasitic",
+          "protomatter. The victim loses 1/1D6 SAN due to",
+          "helplessness.",
+          "SWALLOW: After successfully grappling a victim, Hope",
+          "liquifies herself, surrounds, and engulfs the body in",
+          "a constricting protomatter sac. Hope can then inflict",
+          "2D6 damage to the victim with each action without an",
+          "attack roll. The victim must take an action and roll STR×5",
+          "to break free.",
+        ],
+        attributes: {
+          str: 26,
+          con: 23,
+          dex: 15,
+          int: 11,
+          pow: 10,
+          cha: 14,
+          hp: 19,
+          wp: 10,
+          san: 0,
+        },
+        sanloss: {
+          successLoss: "1",
+          failedLoss: "1d6",
+          type: "unnatural",
+          notes: "if seen as protomatter",
+        },
+        skills: {
+          "art (photography)": 53,
+          athletics: 93,
+          "computer science": 24,
+          "craft (electronics)": 64,
+          "craft (lockpick)": 74,
+          disguise: 74,
+          dodge: 38,
+          drive: 52,
+          persuade: 47,
+          sigint: 61,
+          stealth: 92,
+          "unarmed combat": 44,
+          unnatural: 14,
+        },
+        attacks: [
+          {
+            name: "Slam And Strangle",
+            skillModifier: 44,
+            damage: "2d6",
+            notes: "",
+          },
+          {
+            name: "Grapple",
+            skillModifier: 44,
+            notes: "see “draw close",
+          },
+          {
+            name: "Swallow See “swallow",
+            damage: "special",
+            skillModifier: 0,
+            notes: "",
+          },
+          {
+            name: "Kiss See “kiss",
+            damage: "special",
+            skillModifier: 0,
+            notes: "",
+          },
+          {
+            name: "Mi-go Electric Gun",
+            skillModifier: 27,
+            lethality: 2,
+            notes: "ignores armor",
+          },
+          {
+            name: "Mi-go Electric Gun",
+            skillModifier: 27,
+            lethality: 15,
+            notes: "ignores armor",
+          },
+          {
+            name: "Mi-go Electric Gun",
+            skillModifier: 27,
+            lethality: 25,
+            notes: "ignores armor",
+          },
+        ],
       },
     },
     {
@@ -565,7 +690,6 @@ describe("ParseStatBlock", () => {
     if (expected.notes.length > 0) {
       expect(actualStatBlock.notes.length).toBeGreaterThan(0);
     }
-    actualStatBlock.notes = null;
 
     delete actualStatBlock.notes;
     delete expectedStatBlock.notes;

--- a/test/macros/statblocks/alien-steward-stats.txt
+++ b/test/macros/statblocks/alien-steward-stats.txt
@@ -1,0 +1,51 @@
+Hope
+Hapless protomatter Steward, age 28
+(use Hope’s stats for any Steward)
+STR 26 CON 23 DEX 15 INT 11 POW 10 CHA 14
+HP 19 WP 10 SAN 0
+SKILLS: Art (Photography) 53%, Athletics 93%,
+Computer Science 24%, Craft (Electronics) 64%,
+Craft (Lockpick) 74%, Disguise 74%, Dodge 38%,
+Drive 52%, Persuade 47%, SIGINT 61%, Stealth 92%,
+Unarmed Combat 44%, Unnatural 14%.
+ARMOR: Stewards are unharmed by all melee and
+unarmed blows. Firearms have all damage reduced
+to 1, and Hope regenerates 1D4 HP per round. Fire,
+electricity, acid, chemical irritants, and hypergeometric
+rituals inflict damage normally and stop all
+regeneration for the remainder of combat.
+ATTACKS: Slam and Strangle 44%, damage 2D6.
+Grapple 44%, see “Draw Close.”
+Swallow, damage special, see “Swallow.”
+Kiss, damage special, see “Kiss.”
+Mi-go electric gun 27%, Lethality 2%, 15%, or 25%,
+ignores armor.
+ELECTRIC GUN: This weapon appears as a pulsing,
+softball-sized glob with three dangling tendrils. When
+the weapon is picked up, the tendrils wrap around
+the user’s forearm. The weapon is a biomechanical organism that can eject bolts of electrical current, sort
+of like an electric eel. The charge of lightning emitted
+from the weapon is variable, but Hope has no need
+for anything but the deadliest setting. The only reason
+she would turn down the charge would be to protect
+her beloved Valiant, but in such instances, she gives
+her master the gun and attempts to suffocate or rend his
+enemies up close. The electric gun ignores body armor
+but can be blocked by cover.
+DRAW CLOSE: After a successful grapple, a victim must
+succeed on a STR×5 check opposing Hope’s successful
+attack roll to break free. On a failure, they suffer either
+Swallow or Kiss the next round.
+KISS: Hope spurts protomatter down the grappled victim’s
+throat and takes control of their body. Any Agent
+subjected to the Kiss loses control of their character
+until Hope is destroyed or withdraws her parasitic
+protomatter. The victim loses 1/1D6 SAN due to
+helplessness.
+SWALLOW: After successfully grappling a victim, Hope
+liquifies herself, surrounds, and engulfs the body in
+a constricting protomatter sac. Hope can then inflict
+2D6 damage to the victim with each action without an
+attack roll. The victim must take an action and roll STR×5
+to break free.
+SAN LOSS: 1/1D6 if seen as protomatter.

--- a/test/macros/statblocks/megalomaniac-stats.txt
+++ b/test/macros/statblocks/megalomaniac-stats.txt
@@ -1,0 +1,63 @@
+Ronald “Prince” Valiant/Doug Walters
+Unloved megalomaniac, age 35 in 1997
+(Stats in parentheses are when using the Boost power)
+STR 16 (22) CON 16 (22) DEX 12 (18)
+INT 12 POW 10 CHA 18
+HP 16 (22) WP 10 SAN 0
+SKILLS: Accounting 35%, Alertness 33%, Athletics 63%,
+Bureaucracy 35%, Computer Science 22%, Disguise
+19%, Dodge 33%, Drive 56%, Firearms 62%, First Aid
+34%, Foreign Language (Spanish) 14%, HUMINT 31%,
+Melee Weapons 57%, Military Science 38%, Navigate
+24%, Persuade 59%, Pharmacy 34%, SIGINT 18%,
+Stealth 53%, Survival 38%, Unarmed Combat 73%.
+ATTACKS: Unarmed 73%, damage 1D4 (1D8).
+(After THE MEETING [see page 38], Valiant uses no
+weapons but his hands and his psychic powers.)
+Knife (Marine Ka-Bar) 57%, damage 1D6+1 (1D6+3),
+Armor Piercing 3.
+S&W Model 645 Pistol 62%, damage 1D10.
+Colt M16A2 assault rifle 62%, damage 1D12 or
+Lethality 10%, Armor Piercing 3.
+Luigi Franchi SPAS-12 shotgun 82%, damage
+2D8, ×2 armor.
+Mi-go electric gun 12%, lethality 2%, 15%, or 25%
+(See notes for HOPE on this page).
+OBTRUSIONS: Valiant has awakened several deadly but
+draining gifts called obtrusions. If the Agents confront
+him before he leeches power from his followers (see
+THE MEETING on page 38), he can perform only 1
+Obtrusion. If the Agents interrupt the meeting soon
+after it begins, he can perform 10 Obtrusions. If they
+stop it late, he can perform 20. If they fail to interrupt
+the meeting at all, Valiant can perform 40 Obtrusions.
+Each can be used any number of times at a cost of 1
+Obtrusion per use. Each use is his action for the turn.
+• Ascendance: Valiant can fly up to 50 meters, shining
+brightly. If he has grappled an Agent, he can carry
+them with him. Whatever Valiant’s altitude after
+using this power, he lands safely unless unconscious.
+• Boost: Valiant can add 6 each to his STR, DEX, and
+CON for the next five turns, glowing faintly. He
+starts a fight with this power.
+• Disruption: If he has lost hit points since his last
+action, Valiant can angrily channel a flash of
+force into his hands. The next time he hits with an
+unarmed attack, its damage is Lethality 10%.
+• Impulsion: By touch, Valiant can plant an emotion
+in the target. It lasts 20 hours. To resist the sway of
+this emotion requires succeeding at a WP×5 test and
+then spending 1D6 WP. If the WP cost is too high,
+the target can choose to obey the emotion after all
+rather than spending it.
+• Protection: As an action, Valiant can surround
+himself in a glittering aura that causes all LETHALITY
+rolls to fail and deflects damage. The aura remains
+without his taking further actions, but upon stopping
+30 points of damage, it flickers out.
+• Repulsion: As an action, Valiant can lash out with
+a bright flare of force. This cannot be blocked or
+dodged. He can affect any number of targets within
+5 meters, each costing 1 Obtrusion. Every target
+flies 10 meters, takes 1D6 damage, and is stunned,
+unable to act until they succeed at a CON×5 test.

--- a/test/macros/statblocks/semighoul.txt
+++ b/test/macros/statblocks/semighoul.txt
@@ -1,0 +1,68 @@
+Part Human, Part Ghoul
+Inhuman shapeshifter, age 25.
+STR 25 CON 25 DEX 12 INT 15 POW 13 CHA 11*
+HP 25 WP 13 SAN 0
+* CHA applies only in a human form.
+BONDS: None.
+MOTIVATIONS: Revenge on Delta Green.
+Revenge on Agent Example0.
+(Only as human) Protecting Agent Example1.
+Dissociative identity disorder (transforms into
+Agent Example2).
+Delusions (sometimes can’t distinguish reality from
+the memories of the dead).
+SKILLS: Alertness 65%, Athletics 50%, Criminology 55%,
+Firearms 45%, Foreign Language (Ghoul) 80%, Forensics
+40%, HUMINT 40%, Law 60%, Medicine 45%, Occult
+95%, Pharmacy 75%, Psychotherapy 80%, Science
+(Chemistry) 25%, Search 55%, Stealth 85%, Track (by
+scent) 55%, Unarmed Combat 75%, Unnatural 60%.
+ATTACKS: Claws 75%, damage 1D8, Armor Piercing 3
+(in ghoul form).
+Bite 75%, damage 1D10+2 (in ghoul form; see
+WORRY AND RIP).
+Unarmed 75%, damage 2D4 (in human form).
+CHARNEL VISAGE: In her true form, that of a loathsome
+ghoul, has no CHA stat as humans would
+understand it. Can transform rapidly between her
+native form and any human form consumed with the
+Changeling Feast ritual.
+GIFT OF THE GRAVE: Consuming rotten human flesh
+immediately restores 1D8 HP to an injured ghoul. This
+may be done once per 24 hours.
+IMMORTALITY: A ghoul never grows old, starves to death,
+or perishes through natural causes.
+INHUMAN AGILITY: With a successful Athletics roll,
+a ghoul can leap five meters in any direction from a
+standing position, scale any vertical surface, or drop up
+to 15 meters without damage. At top speed, a ghoul can
+run nearly 60 kph.
+INHUMAN STRENGTH: Adds 1D6 damage to all
+attacks with melee weapons and thrown weapons.
+LIFE UNDERGROUND: A ghoul can burrow through
+earth at up to three meters per minute. Ghouls thrive
+underground. They prefer to breathe air, and may go
+into a sort of torpor if suffocated long enough, but can
+survive indefinitely without it. A ghoul can see in absolute
+darkness, identify things by smell, and hear a human
+heartbeat at a distance of 15 meters.
+MEPHITIC MEMORIES: With an INT test, can bring
+to mind the memories of any of the many human beings
+whose brains it has devoured: insane cultists, MAJESTIC
+researchers, murderers, rapists, Delta Green agents,
+helpless victims, and many others. If the test fumbles, the
+memories come confusingly and heartbreakingly to the
+forefront of her thoughts, beyond her control.
+RESILIENT: A successful Lethality roll does not destroy a
+ghoul, but inflicts HP damage equal to the Lethality rating.
+WORRY AND RIP: After succeeding with a bite attack, a
+ghoul may inflict 1D6 damage on the same target each
+turn, without requiring an attack roll. The ghoul can take
+other actions while holding and worrying a victim. If
+the bite attack pierced the victim’s armor, the “worry
+and rip” damage ignores armor. The victim can attempt
+an opposed STR test as his or her action each turn to
+break free.
+RITUALS: Changeling Feast, Charnel Meditation,
+Obscure Memories.
+SAN LOSS: 0/1D6 (in ghoul form).


### PR DESCRIPTION
## Checklist

<!-- Check one or more: -->

- [ ] This is meant for the next release.
- [x] This is meant for a hotfix.
- [ ] This is a Build System change.
- [ ] This needs more reviewers than normal
- [ ] This intentionally introduces regressions that will be addressed later.
- [ ] The change will require updates to the documentation.
- [ ] Please do not send commits here without coordinating closely with the owner.

## What does this PR do?

Really complicated statblocks from operations such as The New Age cause the parser to fail to parse or to get into infinite
loops. This addresses those issues.

**This PR is not complete. There is another example stat block that needs to be tested before this is ready to merge**

## How to Test

1. Tests are automated, but the actor statblock parser can be used to test different stat blocks

## Related Issue(s)

Closes #452

## Future Work

<!-- Describe any follow-up work, improvements, or additional features related to this PR. -->
